### PR TITLE
Use long long, hexadecimal literal if it's shorter.

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -1,11 +1,11 @@
-with open("basm.bin", "rb") as f:
-    code = f.read()
+import os
+import struct
 
-n = len(code)
-code += bytes([0]) * (4 - n % 4)
+text = "basm.bin"
 
-import array
-s = array.array('i')
-s.frombytes(code)
-r = ",".join(map(str, s))
-print(f"__attribute__((section(\".text\")))a[]={{{r}}};__libc_start_main(){{((int(*)())a)();}}main;")
+code = bytearray((os.path.getsize(text) + 7) // 8 * 8)
+with open(text, "rb") as f:
+    f.readinto(code)
+
+r = ",".join(min(str(i), hex(i), key=len) for i, in struct.iter_unpack("<q", code))
+print('__attribute__((section(".text")))long long a[]={%s};__libc_start_main(){((int(*)())a)();}main;' % r)


### PR DESCRIPTION
(생성되는 C 코드 코드골프용)
16진수 표현이 더 짧은 경우 16진수 사용하게 했어요.
`int[]` 로 하면 효과가 크지 않아서, `long long[]` 으로 바꿨어요.

예시코드로는 1306 바이트에서 -> 1220 바이트로 줄었어요.