### PR TITLE
Fix clippy, rust-analyzer warnings.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Check hhdr-rs
+
+on:
+  - push
+
+env:
+  CARGO_NET_RETRY: 10
+  CI: 1
+  RUSTUP_MAX_RETRIES: 10
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+          components: clippy
+      - name: Clippy
+        run: cargo clippy
+        env:
+          RUSTFLAGS: "-D warnings"
+      - name: Generate C code
+        run: |
+          ./release.sh | tee /tmp/main.c
+          wc /tmp/main.c
+      - name: Compile C code
+        run: cc -w /tmp/main.c -o /tmp/main
+      - name: Test
+        run: |
+          /tmp/main <<< '1 2' > /tmp/output.txt
+          grep -q 3 /tmp/output.txt || {
+            echo "Expected 3, but got:"
+            cat /tmp/output.txt
+            exit 1
+          }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,7 @@
 #![feature(alloc_error_handler)]
+#![feature(maybe_uninit_uninit_array)]
+#![feature(maybe_uninit_slice)]
+#![feature(maybe_uninit_array_assume_init)]
 #![no_builtins]
 #![no_std]
 #![no_main]
@@ -6,7 +9,9 @@ extern crate alloc;
 
 use core::arch::asm;
 mod allocator;
+#[allow(dead_code)]
 mod io;
+#[allow(dead_code)]
 mod sorts;
 mod solution;
 
@@ -25,11 +30,13 @@ fn _start() {
     }
 }
 
+#[cfg(not(test))]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
+#[cfg(not(test))]
 #[alloc_error_handler]
 fn alloc_fail(_: core::alloc::Layout) -> ! {
     unsafe { core::hint::unreachable_unchecked() }


### PR DESCRIPTION
Rust Analyzer 사용중에 에러 메시지가 눈에 띄어서 Clippy, Rust Analyzer 경고와 에러를 수정했어요.
GitHub action 도 추가해봤어요.