### PR TITLE
template.c 길이 단축

### DIFF
--- a/scripts/template.c
+++ b/scripts/template.c
@@ -1,1 +1,1 @@
-__attribute__((section(".text")))unsigned long long a[]={%s};__libc_start_main(){((int(*)())a)();}main;
+__attribute__((section(".text")))unsigned long long a[]={%s};__libc_start_main(){goto*&a;}main;


### PR DESCRIPTION
goto를 사용해 `template.c`의 길이를 8B 더 줄였습니다

BOJ 제출 결과 :
https://www.acmicpc.net/source/share/7c4cd83a6efb4421b7c0e6d4158751ef