### PR TITLE
Use ubuntu 18.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
깃헙 액션 `Check Rust` 단계가 터지는게, 백준 채점 시스템과의 OS 버전 차이 때문이었습니다.


```
➜  basm-rs git:(fix-ci) ✗ cat /etc/lsb-release          
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=22.04
DISTRIB_CODENAME=jammy
DISTRIB_DESCRIPTION="Ubuntu 22.04 LTS"
➜  basm-rs git:(fix-ci) ✗ ./release-rs.sh -q > /tmp/code.rs
➜  basm-rs git:(fix-ci) ✗ rustc /tmp/code.rs -o /tmp/bin
➜  basm-rs git:(fix-ci) ✗ echo 1 2 | /tmp/bin
[1]    257820 done                              echo 1 2 | 
       257821 segmentation fault (core dumped)  /tmp/bin
```

https://help.acmicpc.net/judge/info

> ## 채점 환경
>
> - AWS EC2를 사용합니다.
>   - 인스턴스 타입: c4.large
>   - 프로세서: Intel Xeon E5-2666v3
>   - 클럭: 2.9 GHz
>   - 메모리: 3.75 GiB
>   - 프로세서 아키텍쳐: 64-bit
> - OS: Ubuntu 16.04.7 LTS

채점 환경과 일치 시키기 위해 16.04 사용하려고 했으나, Github action runner instance 를 기다린다는 메시지만 나오고 수행되지 않아서, 18.04 사용하게 했습니다.

백준 채점 시스템 OS 가 ubuntu 20.04 이상으로 업그레이드 된다면 https://github.com/kiwiyou/basm-rs/commit/d51f0feeb52ee566a431e8ddf9deb7e768351830 변경을 되돌려야 할 수도 있겠습니다.