### PR TITLE
Handle overlapping memmove.

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,4 +1,4 @@
-use core::{arch::asm, cmp::Ordering};
+use core::arch::asm;
 
 use crate::solution;
 use basm::allocator;
@@ -18,11 +18,13 @@ fn _start() {
     }
 }
 
+#[cfg(not(test))]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
     unsafe { core::hint::unreachable_unchecked() }
 }
 
+#[cfg(not(test))]
 #[alloc_error_handler]
 fn alloc_fail(_: core::alloc::Layout) -> ! {
     unsafe { core::hint::unreachable_unchecked() }
@@ -31,50 +33,3 @@ fn alloc_fail(_: core::alloc::Layout) -> ! {
 #[cfg(feature = "no-probe")]
 #[no_mangle]
 fn __rust_probestack() {}
-
-#[no_mangle]
-unsafe extern "C" fn memcpy(dest: *mut u8, mut src: *const u8, n: usize) -> *mut u8 {
-    let mut p = dest;
-    for _ in 0..n {
-        *p = *src;
-        p = p.offset(1);
-        src = src.offset(1);
-    }
-    dest
-}
-
-#[no_mangle]
-unsafe extern "C" fn memmove(dest: *mut u8, mut src: *const u8, n: usize) -> *mut u8 {
-    let mut p = dest;
-    for _ in 0..n {
-        *p = *src;
-        p = p.offset(1);
-        src = src.offset(1);
-    }
-    dest
-}
-
-#[no_mangle]
-unsafe extern "C" fn memset(s: *mut u8, c: i32, n: usize) -> *mut u8 {
-    let mut p = s;
-    for _ in 0..n {
-        *p = c as u8;
-        p = p.offset(1);
-    }
-    s
-}
-
-#[no_mangle]
-unsafe extern "C" fn memcmp(mut s1: *const u8, mut s2: *const u8, n: usize) -> i32 {
-    for _ in 0..n {
-        match (*s1).cmp(&*s2) {
-            Ordering::Less => return -1,
-            Ordering::Greater => return 1,
-            _ => {
-                s1 = s1.offset(1);
-                s2 = s2.offset(1);
-            }
-        }
-    }
-    0
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,6 @@ extern crate alloc;
 
 pub mod allocator;
 pub mod io;
+pub mod libc_string;
 pub mod sorts;
 pub mod syscall;

--- a/src/libc_string.rs
+++ b/src/libc_string.rs
@@ -1,0 +1,98 @@
+use core::cmp::Ordering;
+
+#[no_mangle]
+unsafe extern "C" fn memcpy(dest: *mut u8, mut src: *const u8, n: usize) -> *mut u8 {
+    let mut p = dest;
+    for _ in 0..n {
+        *p = *src;
+        p = p.offset(1);
+        src = src.offset(1);
+    }
+    dest
+}
+
+#[no_mangle]
+unsafe extern "C" fn memmove(dest: *mut u8, src: *const u8, n: usize) -> *mut u8 {
+    if src == dest || n == 0 {
+        return dest;
+    }
+
+    if (dest as *const u8) > src && (dest as *const u8) < src.add(n) {
+        // [src ........]
+        //     [dest .......]
+        for i in (0..n).rev() {
+            *dest.add(i) = *src.add(i);
+        }
+    } else if (src > dest as *const u8) && src < dest.add(n) {
+        //     [src ........]
+        // [dest .......]
+        for i in 0..n {
+            *dest.add(i) = *src.add(i);
+        }
+    } else {
+        memcpy(dest, src, n);
+    }
+    dest
+}
+
+#[no_mangle]
+unsafe extern "C" fn memset(s: *mut u8, c: i32, n: usize) -> *mut u8 {
+    let mut p = s;
+    for _ in 0..n {
+        *p = c as u8;
+        p = p.offset(1);
+    }
+    s
+}
+
+#[no_mangle]
+unsafe extern "C" fn memcmp(mut s1: *const u8, mut s2: *const u8, n: usize) -> i32 {
+    for _ in 0..n {
+        match (*s1).cmp(&*s2) {
+            Ordering::Less => return -1,
+            Ordering::Greater => return 1,
+            _ => {
+                s1 = s1.offset(1);
+                s2 = s2.offset(1);
+            }
+        }
+    }
+    0
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn memmove_no_overlap() {
+        let src = b"Hello";
+        let mut dest = [b'!'; 7];
+        unsafe {
+            memmove(dest.as_mut_ptr().offset(1), src.as_ptr(), 5);
+        }
+        assert_eq!(&dest, b"!Hello!");
+    }
+
+    #[test]
+    fn memmove_overlapping_area_src_comes_first() {
+        let mut region = [b'H', b'e', b'l', b'l', b'o', 0, 0, b'!'];
+        //            src ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        //                            ^^^^^^^^^^^^^^^^^^^^^^ dest
+        unsafe {
+            memmove(region.as_mut_ptr().offset(2), region.as_ptr(), 5);
+        }
+        assert_eq!(&region, b"HeHello!");
+    }
+
+    #[test]
+    fn memmove_overlapping_area_dest_comes_first() {
+        let mut region = [0, 0, b'H', b'e', b'l', b'l', b'o', b'!'];
+        //                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ src
+        //           dest ^^^^^^^^^^^^^^^^^^^^^^^
+        unsafe {
+            memmove(region.as_mut_ptr(), region.as_ptr().offset(2), 5);
+        }
+        assert_eq!(&region, b"Hellolo!");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,10 @@
 #![feature(maybe_uninit_slice)]
 #![feature(maybe_uninit_array_assume_init)]
 #![feature(once_cell)]
-#![cfg_attr(not(test), feature(alloc_error_handler), no_builtins, no_std, no_main)]
+#![feature(alloc_error_handler)]
+#![no_builtins]
+#![no_std]
+#![no_main]
 extern crate alloc;
 
 mod codegen;


### PR DESCRIPTION
memmove 복사 영역이 겹치는 경우 처리했습니다.

유닛 테스트로는 동작 확인했는데, 어떤 경우에 memmove 가 쓰이는지 몰라서 `release.sh` 통해서 확인 못해봤습니다.