### PR TITLE
Fix access to uninitialized first item in SegmentTree::from_iter.

### DIFF
--- a/src/collections/segment_tree.rs
+++ b/src/collections/segment_tree.rs
@@ -20,18 +20,18 @@ impl<Op: SegmentOp> SegmentTree<Op> {
         Self { v, n }
     }
 
+    #[allow(clippy::uninit_vec)]
     pub fn from_iter<I>(n: usize, iter: I) -> Self
     where
         I: IntoIterator<Item = Op::T>,
     {
         let off = n.next_power_of_two();
         let mut v = Vec::with_capacity(off * 2);
-        v.push(Op::e());
         // Safety: initializes right before return
         unsafe { v.set_len(off) };
         v.extend(iter.into_iter().take(n));
         v.resize(off * 2, Op::e());
-        for i in (0..off).rev() {
+        for i in (1..off).rev() {
             v[i] = Op::combine(&v[i * 2], &v[i * 2 + 1]);
         }
         Self { v, n: off }
@@ -128,6 +128,6 @@ mod test {
     fn from_iter() {
         let tree: SegmentTree<Add> = SegmentTree::from_iter(3, [1, 2, 3].into_iter());
         assert_eq!(tree.n, 4);
-        assert_eq!(tree.v, [6, 6, 3, 3, 1, 2, 3, 0]);
+        assert_eq!(&tree.v[1..], [6, 3, 3, 1, 2, 3, 0]);
     }
 }

--- a/src/collections/segment_tree.rs
+++ b/src/collections/segment_tree.rs
@@ -20,13 +20,13 @@ impl<Op: SegmentOp> SegmentTree<Op> {
         Self { v, n }
     }
 
-    #[allow(clippy::uninit_vec)]
     pub fn from_iter<I>(n: usize, iter: I) -> Self
     where
         I: IntoIterator<Item = Op::T>,
     {
         let off = n.next_power_of_two();
         let mut v = Vec::with_capacity(off * 2);
+        v.push(Op::e());
         // Safety: initializes right before return
         unsafe { v.set_len(off) };
         v.extend(iter.into_iter().take(n));
@@ -102,5 +102,32 @@ impl<Op: SegmentOp> SegmentTree<Op> {
             }
             p - self.n
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    struct Add {}
+
+    impl SegmentOp for Add {
+        type T = usize;
+        type U = usize;
+        fn e() -> Self::T {
+            0
+        }
+        fn combine(l: &Self::T, r: &Self::T) -> Self::T {
+            l + r
+        }
+        fn apply(_v: &mut Self::T, _u: &Self::U) {
+            unimplemented!()
+        }
+    }
+    #[test]
+    fn from_iter() {
+        let tree: SegmentTree<Add> = SegmentTree::from_iter(3, [1, 2, 3].into_iter());
+        assert_eq!(tree.n, 4);
+        assert_eq!(tree.v, [6, 6, 3, 3, 1, 2, 3, 0]);
     }
 }


### PR DESCRIPTION
https://github.com/kiwiyou/basm-rs/blob/464b7e3a58a2a9da2b631cf81380311d64d9a2fd/src/collections/segment_tree.rs#L35

`i == 0` 일때, `v[0]` 가 초기화 되지 않은 상태에서 접근됩니다. 초기화하게 수정했습니다.