### PR TITLE
Make clippy happy.

### DIFF
--- a/src/collections/jagged_vec.rs
+++ b/src/collections/jagged_vec.rs
@@ -63,7 +63,7 @@ impl<T> JaggedVec<T> {
 
     pub fn first_link(&self, row: usize) -> Option<usize> {
         let head = self.head[row];
-        (head != u32::MAX).then(|| head as usize)
+        (head != u32::MAX).then_some(head as usize)
     }
 }
 
@@ -80,7 +80,7 @@ pub struct RowIter<'a, T> {
 
 impl<'a, T> RowIter<'a, T> {
     pub fn id(&self) -> Option<usize> {
-        (self.idx != u32::MAX).then(|| self.idx as usize)
+        (self.idx != u32::MAX).then_some(self.idx as usize)
     }
 }
 


### PR DESCRIPTION
clippy 경고를 없앱니다.
```rust
    Checking basm v0.1.0 (/home/falsetru/h/basm-rs)
warning: unnecessary closure used with `bool::then`
  --> src/collections/jagged_vec.rs:66:9
   |
66 |         (head != u32::MAX).then(|| head as usize)
   |         ^^^^^^^^^^^^^^^^^^^----------------------
   |                            |
   |                            help: use `then_some(..)` instead: `then_some(head as usize)`
   |
   = note: `#[warn(clippy::unnecessary_lazy_evaluations)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations

warning: unnecessary closure used with `bool::then`
  --> src/collections/jagged_vec.rs:83:9
   |
83 |         (self.idx != u32::MAX).then(|| self.idx as usize)
   |         ^^^^^^^^^^^^^^^^^^^^^^^--------------------------
   |                                |
   |                                help: use `then_some(..)` instead: `then_some(self.idx as usize)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations
```