### PR TITLE
Remove redundant feature attribure; once_cell will be stabilized sinc…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(maybe_uninit_slice)]
 #![feature(maybe_uninit_uninit_array)]
 #![feature(maybe_uninit_array_assume_init)]
-#![feature(once_cell)]
 #![feature(alloc_error_handler)]
 #![cfg_attr(not(test), no_std)]
 extern crate alloc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 #![feature(maybe_uninit_uninit_array)]
 #![feature(maybe_uninit_slice)]
 #![feature(maybe_uninit_array_assume_init)]
-#![feature(once_cell)]
 #![feature(alloc_error_handler)]
 #![no_builtins]
 #![no_std]


### PR DESCRIPTION
…e 1.70.

nightly 에서는 이미 stable feature 라서 attribute 쓸 필요 없어졌어요.
https://github.com/rust-lang/rust/pull/105587