### PR TITLE
Add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
stable을 default channel로 사용하는 유저들 입장에서 일부 toolchain이 올바르지 않은 channel을 사용하는 문제를 해결합니다.

이 유저들이 실행할 때마다 번거롭게 `+nightly`를 붙여야 하는 문제도 해결합니다.