### PR TITLE
Add modmul, modinv, modpow

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,3 +708,34 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 ```
+
+[Go](https://cs.opensource.google/go/go/+/refs/tags/go1.21.5:src/math/bits/bits.go;l=518)
+```
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```

--- a/basm-std/src/math.rs
+++ b/basm-std/src/math.rs
@@ -8,6 +8,8 @@ pub use pollard_rho::factorize;
 pub mod ntt;
 pub use ntt::*;
 
+mod modmul;
+
 // reference: https://nyaannyaan.github.io/library/trial/fast-gcd.hpp.html
 
 use core::ops::*;
@@ -110,6 +112,166 @@ pub fn egcd<T: EgcdOps>(mut a: T, mut b: T) -> (T, T, T) {
     }
 }
 
+pub trait ModOps<T>:
+    Copy
+    + PartialOrd
+    + Add<Output = Self>
+    + Sub<Output = Self>
+    + Mul<Output = Self>
+    + Div<Output = Self>
+    + Rem<Output = Self>
+{
+    fn zero() -> T;
+    fn one() -> T;
+    fn two() -> T;
+    fn my_wrapping_sub(&self, other: T) -> T;
+    fn modinv(&self, modulo: T) -> Option<T>;
+    fn modmul(x: T, y: T, modulo: T) -> T;
+}
+
+macro_rules! impl_mod_ops_signed {
+    ($($t:ty),*) => { $(
+        impl ModOps<$t> for $t {
+            fn zero() -> $t { 0 }
+            fn one() -> $t { 1 }
+            fn two() -> $t { 2 }
+            fn my_wrapping_sub(&self, other: $t) -> $t { self.wrapping_sub(other) }
+            fn modinv(&self, modulo: $t) -> Option<$t> {
+                assert!(modulo > 0);
+                let (g, x, _y) = egcd(*self, modulo);
+                if g == 1 {
+                    let out = x % modulo;
+                    Some(if out < 0 { out + modulo } else { out })
+                } else {
+                    None
+                }
+            }
+            fn modmul(x: $t, y: $t, modulo: $t) -> $t {
+                debug_assert!(modulo > 0);
+                const BITS: usize = core::mem::size_of::<$t>() * 8;
+                if BITS <= 16 {
+                    ((x as i32) * (y as i32) % (modulo as i32)) as $t
+                } else if BITS <= 32 {
+                    ((x as i64) * (y as i64) % (modulo as i64)) as $t
+                } else if BITS <= 64 {
+                    ((x as i128) * (y as i128) % (modulo as i128)) as $t
+                } else if BITS <= 128 {
+                    let mut x_tmp = x % modulo;
+                    if x_tmp < 0 { x_tmp += modulo; }
+                    let mut y_tmp = y % modulo;
+                    if y_tmp < 0 { y_tmp += modulo; }
+                    modmul::modmul128(x_tmp as u128, y_tmp as u128, modulo as u128) as $t
+                } else {
+                    panic!("Unsupported number of bits: {BITS}")
+                }
+            }
+        }
+    )* };
+}
+impl_mod_ops_signed!(i8, i16, i32, i64, i128, isize);
+
+macro_rules! impl_mod_ops_unsigned {
+    ($($t:ty),*) => { $(
+        impl ModOps<$t> for $t {
+            fn zero() -> $t { 0 }
+            fn one() -> $t { 1 }
+            fn two() -> $t { 2 }
+            fn my_wrapping_sub(&self, other: $t) -> $t { self.wrapping_sub(other) }
+            fn modinv(&self, modulo: $t) -> Option<$t> {
+                if modulo <= 1 {
+                    return None;
+                }
+                fn modsub(x: $t, mut y: $t, modulo: $t) -> $t {
+                    y %= modulo;
+                    let (out, overflow) = x.overflowing_sub(y);
+                    if overflow { out.wrapping_add(modulo) } else { out }
+                }
+                let (mut a, mut b) = (*self, modulo);
+                let mut c: [$t; 4] = if a > b {
+                    (a, b) = (b, a);
+                    [0, 1, 1, 0]
+                } else {
+                    [1, 0, 0, 1]
+                }; // treat as a row-major 2x2 matrix
+                loop {
+                    if a == 0 {
+                        if b == 1 {
+                            break Some(c[1]);
+                        } else if b == modulo - 1 {
+                            break Some(modsub(0, c[1], modulo));
+                        } else {
+                            break None;
+                        }
+                    }
+                    let (q, r) = (b / a, b % a);
+                    (a, b) = (r, a);
+                    c = [modsub(c[1], q * c[0], modulo), c[0], modsub(c[3], q * c[2], modulo), c[2]];
+                }
+            }
+            fn modmul(x: $t, y: $t, modulo: $t) -> $t {
+                const BITS: usize = core::mem::size_of::<$t>() * 8;
+                if BITS <= 16 {
+                    ((x as u32) * (y as u32) % (modulo as u32)) as $t
+                } else if BITS <= 32 {
+                    ((x as u64) * (y as u64) % (modulo as u64)) as $t
+                } else if BITS <= 64 {
+                    ((x as u128) * (y as u128) % (modulo as u128)) as $t
+                } else if BITS <= 128 {
+                    modmul::modmul128(x as u128, y as u128, modulo as u128) as $t
+                } else {
+                    panic!("Unsupported number of bits: {BITS}")
+                }
+            }
+        }
+    )* };
+}
+impl_mod_ops_unsigned!(u8, u16, u32, u64, u128, usize);
+
+/// Computes the modular multiplication of `x` and `y`.
+/// 
+/// This function will panic if `modulo` is zero or negative.
+pub fn modmul<T: ModOps<T>>(x: T, y: T, modulo: T) -> T {
+    T::modmul(x, y, modulo)
+}
+
+/// Computes the inverse of `x` mod `modulo`, if it exists.
+/// Returns `None` if the inverse does not exist.
+///
+/// This function will panic if `modulo` is non-positive.
+pub fn modinv<T: ModOps<T>>(x: T, modulo: T) -> Option<T> {
+    x.modinv(modulo)
+}
+
+/// Computes `base ** exponent` mod `modulo` in `O(lg exponent)` time.
+/// Returns `None` if the exponent is negative and `base` is not invertible mod `modulo`.
+///
+/// This function will panic if `modulo` is non-positive.
+pub fn modpow<T: ModOps<T>>(mut base: T, mut exponent: T, modulo: T) -> Option<T> {
+    assert!(modulo > T::zero());
+    let mut out = T::one();
+    if exponent < T::zero() {
+        /* check for invertibility of base with respect to mod modulo */
+        if let Some(x) = modinv(base, modulo) {
+            base = x;
+        } else {
+            return None;
+        }
+        exponent = T::zero()
+            .my_wrapping_sub(exponent)
+            .my_wrapping_sub(T::one());
+        out = base % modulo;
+    }
+    let mut base_pow = base % modulo;
+    while exponent > T::zero() {
+        if (exponent % T::two()) != T::zero() {
+            out = T::modmul(out, base_pow, modulo);
+        }
+        base_pow = T::modmul(base_pow, base_pow, modulo);
+        exponent = exponent / T::two();
+    }
+    Some(out)
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -142,5 +304,27 @@ mod test {
         let normal = gcd(a as u64, b as u64) as i128;
         assert_eq!(normal, g);
         assert_eq!(a * s + b * t, g);
+    }
+
+    #[test]
+    fn modinv_returns_modinv() {
+        assert_eq!(None, modinv(4i64, 16i64));
+        assert_eq!(None, modinv(301i64, 7i64));
+        assert_eq!(Some(4i64), modinv(3i64, 11i64));
+        assert_eq!(Some(4u64), modinv(3u64, 11u64));
+        let p = 0u64.wrapping_sub((1u64 << 32) - 1);
+        assert_eq!(Some((p + 1) / 2), modinv(2u64, p));
+    }
+
+    #[test]
+    fn modpow_returns_modpow() {
+        assert_eq!(Some(0i64), modpow(4i64, 4i64, 16i64));
+        assert_eq!(None, modpow(4i64, -4i64, 16i64));
+        assert_eq!(Some(1i64), modpow(2i64, 1_000_000_006i64, 1_000_000_007i64));
+        assert_eq!(Some(1u64), modpow(2u64, 1_000_000_006u64, 1_000_000_007u64));
+        let p = 0u64.wrapping_sub((1u64 << 32) - 1);
+        assert_eq!(Some(1u64), modpow(2u64, p - 1, p));
+        let p128 = 0u128.wrapping_sub(159);
+        assert_eq!(Some(1u128), modpow(2u128, p128 - 1, p128));
     }
 }

--- a/basm-std/src/math.rs
+++ b/basm-std/src/math.rs
@@ -148,21 +148,20 @@ macro_rules! impl_mod_ops_signed {
             }
             fn modmul(x: $t, y: $t, modulo: $t) -> $t {
                 debug_assert!(modulo > 0);
-                const BITS: usize = core::mem::size_of::<$t>() * 8;
-                if BITS <= 16 {
+                if <$t>::BITS <= 16 {
                     ((x as i32) * (y as i32) % (modulo as i32)) as $t
-                } else if BITS <= 32 {
+                } else if <$t>::BITS <= 32 {
                     ((x as i64) * (y as i64) % (modulo as i64)) as $t
-                } else if BITS <= 64 {
+                } else if <$t>::BITS <= 64 {
                     ((x as i128) * (y as i128) % (modulo as i128)) as $t
-                } else if BITS <= 128 {
+                } else if <$t>::BITS <= 128 {
                     let mut x_tmp = x % modulo;
                     if x_tmp < 0 { x_tmp += modulo; }
                     let mut y_tmp = y % modulo;
                     if y_tmp < 0 { y_tmp += modulo; }
                     modmul::modmul128(x_tmp as u128, y_tmp as u128, modulo as u128) as $t
                 } else {
-                    panic!("Unsupported number of bits: {BITS}")
+                    panic!("Unsupported number of bits: {}", <$t>::BITS)
                 }
             }
         }
@@ -209,17 +208,16 @@ macro_rules! impl_mod_ops_unsigned {
                 }
             }
             fn modmul(x: $t, y: $t, modulo: $t) -> $t {
-                const BITS: usize = core::mem::size_of::<$t>() * 8;
-                if BITS <= 16 {
+                if <$t>::BITS <= 16 {
                     ((x as u32) * (y as u32) % (modulo as u32)) as $t
-                } else if BITS <= 32 {
+                } else if <$t>::BITS <= 32 {
                     ((x as u64) * (y as u64) % (modulo as u64)) as $t
-                } else if BITS <= 64 {
+                } else if <$t>::BITS <= 64 {
                     ((x as u128) * (y as u128) % (modulo as u128)) as $t
-                } else if BITS <= 128 {
+                } else if <$t>::BITS <= 128 {
                     modmul::modmul128(x as u128, y as u128, modulo as u128) as $t
                 } else {
-                    panic!("Unsupported number of bits: {BITS}")
+                    panic!("Unsupported number of bits: {}", <$t>::BITS)
                 }
             }
         }

--- a/basm-std/src/math/modmul.rs
+++ b/basm-std/src/math/modmul.rs
@@ -1,0 +1,83 @@
+const TWO64: u128 = 1u128 << 64;
+const MASK64: u128 = TWO64 - 1;
+
+/// Computes `(x / modulo, x % modulo)`, where `x = hi * (2 ** 128) + lo`.
+/// Panics if `modulo` is zero (division by zero) or `hi >= y` (quotient overflow).
+/// The current implementation is based on
+/// https://cs.opensource.google/go/go/+/refs/tags/go1.21.5:src/math/bits/bits.go;l=518,
+/// which is again based on the Algorithm 4.3.1 D of Donald Knuth's TAOCP.
+fn divmod128(hi: u128, lo: u128, modulo: u128) -> (u128, u128) {
+    let mut y = modulo;
+    debug_assert!(y > 0);
+    debug_assert!(hi < y);
+
+    // If high part is zero, we can directly return the results.
+    if hi == 0 {
+        return (lo / y, lo % y);
+    }
+
+    let s: u32 = y.leading_zeros();
+    y <<= s;
+
+    let yn1 = y >> 64;
+    let yn0 = y & MASK64;
+    let un32 = if s == 0 { hi } else { (hi << s) | (lo >> (128 - s)) };
+    let un10 = lo << s;
+    let un1 = un10 >> 64;
+    let un0 = un10 & MASK64;
+    let mut q1 = un32 / yn1;
+    let mut rhat = un32 - q1 * yn1;
+
+    while q1 >= TWO64 || q1 * yn0 > TWO64 * rhat + un1 {
+        q1 -= 1;
+        rhat += yn1;
+        if rhat >= TWO64 {
+            break;
+        }
+    }
+
+    let un21 = un32.wrapping_mul(TWO64).wrapping_add(un1).wrapping_sub(q1.wrapping_mul(y));
+    let mut q0 = un21 / yn1;
+    let mut rhat = un21 - q0 * yn1;
+
+    while q0 >= TWO64 || q0 * yn0 > TWO64 * rhat + un0 {
+        q0 -= 1;
+        rhat += yn1;
+        if rhat >= TWO64 {
+            break;
+        }
+    }
+
+    (q1 * TWO64 + q0, (un21.wrapping_mul(TWO64).wrapping_add(un0).wrapping_sub(q0.wrapping_mul(y))) >> s)
+}
+
+/// Computes the modular multiplication of `x` and `y` mod `modulo`.
+/// Panics if `modulo` is zero.
+pub fn modmul128(x: u128, y: u128, modulo: u128) -> u128 {
+    debug_assert!(modulo > 0);
+    let (xh, xl) = (x >> 64, x & MASK64);
+    let (yh, yl) = (y >> 64, y & MASK64);
+    let mut hi = xh * yh;
+    let lo = xl * yl;
+    let (mid, overflow) = (xh * yl).overflowing_add(xl * yh);
+    if overflow {
+        hi += TWO64;
+    }
+    let (lo, overflow) = lo.overflowing_add(mid << 64);
+    if overflow {
+        hi += 1;
+    }
+    hi += mid >> 64;
+    divmod128(hi % modulo, lo, modulo).1
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn modmul128_returns_modmul128() {
+        let p128 = 0u128.wrapping_sub(159);
+        assert_eq!(6, modmul128(p128 - 3, p128 - 2, p128));
+    }
+}


### PR DESCRIPTION
* `basm::math::{modmul, modinv, modpow}` 추가
* 128비트 모듈로 곱셈을 지원하기 위해 Go의 `Div64` 루틴을 Rust로 포팅하고 128비트용으로 수정
  * 이에 맞추어 README.md의 license notice를 업데이트함