### PR TITLE
Fix test/bench

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-rustflags = ["-Z", "export-executable-symbols", "-C", "target-feature=+avx,+avx2,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+fma,+f16c,+aes", "-C", "relocation-model=pie", "-C", "target-cpu=haswell"]
+rustflags = ["-Z", "share-generics=no", "-Z", "export-executable-symbols", "-C", "target-feature=+avx,+avx2,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+fma,+f16c,+aes", "-C", "relocation-model=pie", "-C", "target-cpu=haswell"]
 
 [target.wasm32-unknown-unknown]
-rustflags = ["-C", "link-args=-z stack-size=67108864"]
+rustflags = ["-Z", "share-generics=no", "-C", "link-args=-z stack-size=67108864"]

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -47,8 +47,6 @@ jobs:
       - name: Test
         if: ${{ matrix.target != 'wasm32-unknown-unknown' }}
         run: cargo test --lib -- --test-threads 1
-        env:
-          RUSTFLAGS: ""
       - name: Check C (x86_64)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         run: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -48,8 +48,6 @@ jobs:
       - name: Test
         if: ${{ matrix.target != 'wasm32-unknown-unknown' }}
         run: cargo test --lib -- --test-threads 1
-        env:
-          RUSTFLAGS: ""
       - name: Check C (x86_64)
         if: ${{ matrix.target == 'x86_64-pc-windows-msvc' }}
         run: |

--- a/basm/Cargo.toml
+++ b/basm/Cargo.toml
@@ -6,7 +6,6 @@ default-run = "basm"
 autobins = false
 
 [lib]
-name = "basm_lib"
 test = true
 bench = true
 path = "src/bin/basm-lib.rs"

--- a/basm/Cargo.toml
+++ b/basm/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2021"
 default-run = "basm"
 autobins = false
 
+[lib]
+name = "basm_lib"
+test = true
+bench = true
+path = "src/bin/basm-lib.rs"
+
 [[bin]]
 name = "basm"
 test = false

--- a/basm/src/bin/basm-lib.rs
+++ b/basm/src/bin/basm-lib.rs
@@ -11,13 +11,6 @@ extern crate alloc;
 
 extern crate basm_std as basm;
 
-#[cfg_attr(test, allow(dead_code))]
+#[allow(dead_code)]
 #[path = "../solution.rs"]
 mod solution;
-mod codegen;
-
-#[cfg(not(test))]
-#[panic_handler]
-fn panic(_pi: &core::panic::PanicInfo) -> ! {
-    unsafe { core::hint::unreachable_unchecked() }
-}

--- a/basm/src/bin/basm-lib.rs
+++ b/basm/src/bin/basm-lib.rs
@@ -14,3 +14,15 @@ extern crate basm_std as basm;
 #[allow(dead_code)]
 #[path = "../solution.rs"]
 mod solution;
+
+#[cfg(test)]
+mod verify_test_works {
+    fn add(x: i64, y: i64) -> i64 {
+        x + y
+    }
+
+    #[test]
+    fn run() {
+        assert_eq!(8, add(5, 3));
+    }
+}

--- a/basm/src/bin/basm.rs
+++ b/basm/src/bin/basm.rs
@@ -16,6 +16,7 @@ extern crate basm_std as basm;
 mod solution;
 mod codegen;
 
+#[cfg(not(test))]
 #[panic_handler]
 fn panic(_pi: &core::panic::PanicInfo) -> ! {
     use alloc::string::ToString;


### PR DESCRIPTION
* `basm` crate 내부에 bin target이 아닌 test에 사용되는 lib target을 신설하였습니다.
* `RUSTFLAGS="-Z share-generics=no"` 옵션을 활성화하여 error LNK1120 (Windows MSVC) / undefined reference (Linux LLVM) 오류를 임시로 회피하도록 조치하였습니다.

이상의 코드 수정에 따라 `basm/src/solution.rs`에서 `#[test]` annotation을 통한 테스팅 기능이 정상적으로 작동합니다.