### PR TITLE
Fix windows bloat

### DIFF
--- a/basm/build.rs
+++ b/basm/build.rs
@@ -17,6 +17,7 @@ fn main() {
             link_args_basm.push("/EMITTOOLVERSIONINFO:NO");
             link_args_basm.push("/EMITPOGOPHASEINFO");
             link_args_basm_submit.push("/ALIGN:128");
+            link_args_basm_submit.push("/OPT:REF,ICF");
         },
         "x86_64-unknown-linux-gnu" | "x86_64-unknown-linux-gnu-short" | "i686-unknown-linux-gnu" => {
             link_args_basm.push("-nostartfiles");

--- a/scripts/static-pie-pe2bin.py
+++ b/scripts/static-pie-pe2bin.py
@@ -80,11 +80,12 @@ if __name__ == '__main__':
 
     # Process exports
     exports = dict()
-    for e in pe.DIRECTORY_ENTRY_EXPORT.symbols:
-        e_name = None if e.name is None else e.name.decode('utf8')
-        if e_name.startswith("_basm_export_") or e_name.startswith("_basm_import_"):
-            assert e.address >= pos_begin
-            exports[e_name] = e.address
+    if hasattr(pe, "DIRECTORY_ENTRY_EXPORT"):
+        for e in pe.DIRECTORY_ENTRY_EXPORT.symbols:
+            e_name = None if e.name is None else e.name.decode('utf8')
+            if e_name.startswith("_basm_export_") or e_name.startswith("_basm_import_"):
+                assert e.address >= pos_begin
+                exports[e_name] = e.address
 
     fdict = {}
     fdict['entrypoint_offset'] = entrypoint_offset


### PR DESCRIPTION
* Currently, `RUSTFLAGS="-Z export-executable-symbols"` will call `Linker::no_gc_sections`, which is implemented to set `/OPT:NOREF,NOICF` for `MsvcLinker`. Hence, we override it in the build script.
* For future changes, we modify PE processing script to not panic when there are no exported symbols. Currently, this change is a no-op since we unconditionally export a few symbols, like `__chkstk` and `_fltused`.