### PR TITLE
CI: remove duplicated test declarations

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -50,60 +50,24 @@ jobs:
       - name: Check C (x86_64)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         run: |
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release.sh C 64 ./basm/src/solution.rs ./tests/boj_1000.in ./tests/boj_1000.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release.sh C 64 ./tests/boj_1001.rs ./tests/boj_1001.in ./tests/boj_1001.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release.sh C 64 ./tests/boj_2587.rs ./tests/boj_2587.in ./tests/boj_2587.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release.sh C 64 ./tests/boj_2751.rs ./tests/boj_2751.in.zip ./tests/boj_2751.out.zip
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release.sh C 64 ./tests/boj_3745.rs ./tests/boj_3745.in ./tests/boj_3745.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release.sh C 64 ./tests/boj_14939.rs ./tests/boj_14939.in ./tests/boj_14939.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release.sh C 64 ./tests/reloc.rs ./tests/reloc.in ./tests/reloc.out
+          python ./scripts/ci.py ${{ runner.temp }} ./release.sh C 64 ./tests/ci.json
       - name: Check C (x86_64) - short
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         run: |
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./.github/workflows/release-short.sh C 64 ./basm/src/solution.rs ./tests/boj_1000.in ./tests/boj_1000.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./.github/workflows/release-short.sh C 64 ./tests/boj_1001.rs ./tests/boj_1001.in ./tests/boj_1001.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./.github/workflows/release-short.sh C 64 ./tests/boj_2587.rs ./tests/boj_2587.in ./tests/boj_2587.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./.github/workflows/release-short.sh C 64 ./tests/boj_2751.rs ./tests/boj_2751.in.zip ./tests/boj_2751.out.zip
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./.github/workflows/release-short.sh C 64 ./tests/boj_3745.rs ./tests/boj_3745.in ./tests/boj_3745.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./.github/workflows/release-short.sh C 64 ./tests/boj_14939.rs ./tests/boj_14939.in ./tests/boj_14939.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./.github/workflows/release-short.sh C 64 ./tests/reloc.rs ./tests/reloc.in ./tests/reloc.out
+          python ./scripts/ci.py ${{ runner.temp }} ./.github/workflows/release-short.sh C 64 ./tests/ci.json
       - name: Check C (x86)
         if: ${{ matrix.target == 'i686-unknown-linux-gnu' }}
         run: |
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-32bit.sh C 32 ./basm/src/solution.rs ./tests/boj_1000.in ./tests/boj_1000.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-32bit.sh C 32 ./tests/boj_1001.rs ./tests/boj_1001.in ./tests/boj_1001.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-32bit.sh C 32 ./tests/boj_2587.rs ./tests/boj_2587.in ./tests/boj_2587.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-32bit.sh C 32 ./tests/boj_2751.rs ./tests/boj_2751.in.zip ./tests/boj_2751.out.zip
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-32bit.sh C 32 ./tests/boj_3745.rs ./tests/boj_3745.in ./tests/boj_3745.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-32bit.sh C 32 ./tests/boj_14939.rs ./tests/boj_14939.in ./tests/boj_14939.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-32bit.sh C 32 ./tests/reloc.rs ./tests/reloc.in ./tests/reloc.out
+          python ./scripts/ci.py ${{ runner.temp }} ./release-32bit.sh C 32 ./tests/ci.json
       - name: Check Rust (x86_64)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         run: |
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-rs.sh Rust 64 ./basm/src/solution.rs ./tests/boj_1000.in ./tests/boj_1000.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-rs.sh Rust 64 ./tests/boj_1001.rs ./tests/boj_1001.in ./tests/boj_1001.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-rs.sh Rust 64 ./tests/boj_2587.rs ./tests/boj_2587.in ./tests/boj_2587.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-rs.sh Rust 64 ./tests/boj_2751.rs ./tests/boj_2751.in.zip ./tests/boj_2751.out.zip
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-rs.sh Rust 64 ./tests/boj_3745.rs ./tests/boj_3745.in ./tests/boj_3745.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-rs.sh Rust 64 ./tests/boj_14939.rs ./tests/boj_14939.in ./tests/boj_14939.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-rs.sh Rust 64 ./tests/reloc.rs ./tests/reloc.in ./tests/reloc.out
+          python ./scripts/ci.py ${{ runner.temp }} ./release-rs.sh Rust 64 ./tests/ci.json
       - name: Check Rust (x86_64) - short
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         run: |
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./.github/workflows/release-rs-short.sh Rust 64 ./basm/src/solution.rs ./tests/boj_1000.in ./tests/boj_1000.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./.github/workflows/release-rs-short.sh Rust 64 ./tests/boj_1001.rs ./tests/boj_1001.in ./tests/boj_1001.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./.github/workflows/release-rs-short.sh Rust 64 ./tests/boj_2587.rs ./tests/boj_2587.in ./tests/boj_2587.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./.github/workflows/release-rs-short.sh Rust 64 ./tests/boj_2751.rs ./tests/boj_2751.in.zip ./tests/boj_2751.out.zip
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./.github/workflows/release-rs-short.sh Rust 64 ./tests/boj_3745.rs ./tests/boj_3745.in ./tests/boj_3745.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./.github/workflows/release-rs-short.sh Rust 64 ./tests/boj_14939.rs ./tests/boj_14939.in ./tests/boj_14939.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./.github/workflows/release-rs-short.sh Rust 64 ./tests/reloc.rs ./tests/reloc.in ./tests/reloc.out
+          python ./scripts/ci.py ${{ runner.temp }} ./.github/workflows/release-rs-short.sh Rust 64 ./tests/ci.json
       - name: Check wasm32
         if: ${{ matrix.target == 'wasm32-unknown-unknown' }}
         run: |
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-wasm32.sh JavaScript 32 ./basm/src/solution.rs ./tests/boj_1000.in ./tests/boj_1000.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-wasm32.sh JavaScript 32 ./tests/boj_1001.rs ./tests/boj_1001.in ./tests/boj_1001.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-wasm32.sh JavaScript 32 ./tests/boj_2587.rs ./tests/boj_2587.in ./tests/boj_2587.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-wasm32.sh JavaScript 32 ./tests/boj_2751.rs ./tests/boj_2751.in.zip ./tests/boj_2751.out.zip
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-wasm32.sh JavaScript 32 ./tests/boj_3745.rs ./tests/boj_3745.in ./tests/boj_3745.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-wasm32.sh JavaScript 32 ./tests/boj_14939.rs ./tests/boj_14939.in ./tests/boj_14939.out
-          python ./scripts/build-and-judge.py ${{ runner.temp }} ./release-wasm32.sh JavaScript 32 ./tests/reloc.rs ./tests/reloc.in ./tests/reloc.out
+          python ./scripts/ci.py ${{ runner.temp }} ./release-wasm32.sh JavaScript 32 ./tests/ci.json

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -51,30 +51,12 @@ jobs:
       - name: Check C (x86_64)
         if: ${{ matrix.target == 'x86_64-pc-windows-msvc' }}
         run: |
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-64bit-windows.cmd C 64 .\basm\src\solution.rs .\tests\boj_1000.in .\tests\boj_1000.out
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-64bit-windows.cmd C 64 .\tests\boj_1001.rs .\tests\boj_1001.in .\tests\boj_1001.out
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-64bit-windows.cmd C 64 .\tests\boj_2587.rs .\tests\boj_2587.in .\tests\boj_2587.out
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-64bit-windows.cmd C 64 .\tests\boj_2751.rs .\tests\boj_2751.in.zip .\tests\boj_2751.out.zip
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-64bit-windows.cmd C 64 .\tests\boj_3745.rs .\tests\boj_3745.in .\tests\boj_3745.out
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-64bit-windows.cmd C 64 .\tests\boj_14939.rs .\tests\boj_14939.in .\tests\boj_14939.out
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-64bit-windows.cmd C 64 .\tests\reloc.rs .\tests\reloc.in .\tests\reloc.out
+          python .\scripts\ci.py ${{ runner.temp }} .\release-64bit-windows.cmd C 64 .\tests\ci.json
       - name: Check Rust (x86_64)
         if: ${{ matrix.target == 'x86_64-pc-windows-msvc' }}
         run: |
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-64bit-windows-rs.cmd Rust 64 .\basm\src\solution.rs .\tests\boj_1000.in .\tests\boj_1000.out
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-64bit-windows-rs.cmd Rust 64 .\tests\boj_1001.rs .\tests\boj_1001.in .\tests\boj_1001.out
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-64bit-windows-rs.cmd Rust 64 .\tests\boj_2587.rs .\tests\boj_2587.in .\tests\boj_2587.out
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-64bit-windows-rs.cmd Rust 64 .\tests\boj_2751.rs .\tests\boj_2751.in.zip .\tests\boj_2751.out.zip
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-64bit-windows-rs.cmd Rust 64 .\tests\boj_3745.rs .\tests\boj_3745.in .\tests\boj_3745.out
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-64bit-windows-rs.cmd Rust 64 .\tests\boj_14939.rs .\tests\boj_14939.in .\tests\boj_14939.out
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-64bit-windows-rs.cmd Rust 64 .\tests\reloc.rs .\tests\reloc.in .\tests\reloc.out
+          python .\scripts\ci.py ${{ runner.temp }} .\release-64bit-windows-rs.cmd Rust 64 .\tests\ci.json
       - name: Check wasm32
         if: ${{ matrix.target == 'wasm32-unknown-unknown' }}
         run: |
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-wasm32.cmd JavaScript 32 .\basm\src\solution.rs .\tests\boj_1000.in .\tests\boj_1000.out
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-wasm32.cmd JavaScript 32 .\tests\boj_1001.rs .\tests\boj_1001.in .\tests\boj_1001.out
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-wasm32.cmd JavaScript 32 .\tests\boj_2587.rs .\tests\boj_2587.in .\tests\boj_2587.out
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-wasm32.cmd JavaScript 32 .\tests\boj_2751.rs .\tests\boj_2751.in.zip .\tests\boj_2751.out.zip
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-wasm32.cmd JavaScript 32 .\tests\boj_3745.rs .\tests\boj_3745.in .\tests\boj_3745.out
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-wasm32.cmd JavaScript 32 .\tests\boj_14939.rs .\tests\boj_14939.in .\tests\boj_14939.out
-          python .\scripts\build-and-judge.py ${{ runner.temp }} .\release-wasm32.cmd JavaScript 32 .\tests\reloc.rs .\tests\reloc.in .\tests\reloc.out
+          python .\scripts\ci.py ${{ runner.temp }} .\release-wasm32.cmd JavaScript 32 .\tests\ci.json

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -1,0 +1,57 @@
+"""
+This script builds and tests solutions to multiple problems.
+Developed for use in CI.
+Usage:
+    python scripts/ci.py [tmp-dir] [build-cmd] [language] [bits] [ci-json-path]
+Example:
+    python scripts/ci.py tmp/test release-64bit-windows-rs.cmd Rust 64 tests/ci.json
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+if __name__ == "__main__":
+    with open("tests/ci.json", "r") as f:
+        ci_jobs = json.load(f)
+
+    try:
+        tmp_dir = sys.argv[1]
+        build_cmd = sys.argv[2]
+        language = sys.argv[3]
+        bits = sys.argv[4]
+    except:
+        raise Exception("\n".join([
+            "",
+            "",
+            "**Error: incorrect argument**",
+            "",
+            "This script builds and tests solutions to multiple problems.",
+            "Developed for use in CI.",
+            "Usage:",
+            "    python scripts/ci.py [tmp-dir] [build-cmd] [language] [bits] [ci-json-path]",
+            "Example:",
+            "    python scripts/ci.py tmp/test release-64bit-windows-rs.cmd Rust 64 tests/ci.json"
+        ]))
+
+    for job in ci_jobs:
+        sol_path = job["solution"]
+        indata_path = job["input"]
+        outdata_path = job["output"]
+        completed_process = subprocess.run([
+            "python",
+            "./scripts/build-and-judge.py",
+            tmp_dir,
+            build_cmd,
+            language,
+            bits,
+            sol_path,
+            indata_path,
+            outdata_path
+        ], shell=True, capture_output=False, text=True)
+        if completed_process.returncode != 0:
+            raise Exception("Test script terminated with a non-zero exit code {}.".format(completed_process.returncode))
+
+    print("--------")
+    print("Successfully completed {} job{} for [{} {} {}] (tmp dir: {}).".format(len(ci_jobs), "s" if len(ci_jobs) > 1 else "", build_cmd, language, bits, tmp_dir))

--- a/tests/ci.json
+++ b/tests/ci.json
@@ -1,0 +1,37 @@
+[
+    {
+        "solution": "./basm/src/solution.rs",
+        "input": "./tests/boj_1000.in",
+        "output": "./tests/boj_1000.out"
+    },
+    {
+        "solution": "./tests/boj_1001.rs",
+        "input": "./tests/boj_1001.in",
+        "output": "./tests/boj_1001.out"
+    },
+    {
+        "solution": "./tests/boj_2587.rs",
+        "input": "./tests/boj_2587.in",
+        "output": "./tests/boj_2587.out"
+    },
+    {
+        "solution": "./tests/boj_2751.rs",
+        "input": "./tests/boj_2751.in.zip",
+        "output": "./tests/boj_2751.out.zip"
+    },
+    {
+        "solution": "./tests/boj_3745.rs",
+        "input": "./tests/boj_3745.in",
+        "output": "./tests/boj_3745.out"
+    },
+    {
+        "solution": "./tests/boj_14939.rs",
+        "input": "./tests/boj_14939.in",
+        "output": "./tests/boj_14939.out"
+    },
+    {
+        "solution": "./tests/reloc.rs",
+        "input": "./tests/reloc.in",
+        "output": "./tests/reloc.out"
+    }
+]


### PR DESCRIPTION
* CI에서 tests/ci.json 파일에 기록된 테스트 항목을 실행하도록 변경하였습니다. 이전에는 (플랫폼, 테스트) 조합이 workflow yml 파일에 기록되어 중복이 많고 테스트를 추가/제거하기가 어려웠습니다. 이제는 tests/ci.json 하나만 수정하면 됩니다.