### PR TITLE
CI: add macOS

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,8 @@
 [build]
 rustflags = ["-Z", "share-generics=no", "-Z", "export-executable-symbols", "-C", "target-feature=+avx,+avx2,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+fma,+f16c,+aes", "-C", "relocation-model=pie", "-C", "target-cpu=haswell"]
 
+[target.aarch64-apple-darwin]
+rustflags = ["-Z", "share-generics=no", "-Z", "export-executable-symbols", "-C", "relocation-model=pie"]
+
 [target.wasm32-unknown-unknown]
 rustflags = ["-Z", "share-generics=no", "-C", "link-args=-z stack-size=67108864"]

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -30,6 +30,10 @@ jobs:
           profile: default
           override: true
           components: clippy
+      - name: Install Python 3      
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - name: Install node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -53,4 +53,4 @@ jobs:
       - name: Check wasm32
         if: ${{ matrix.target == 'wasm32-unknown-unknown' }}
         run: |
-          python ./scripts/ci.py ${{ runner.temp }} ./release-wasm32.sh JavaScript 32 ./tests/ci.json
+          python3 ./scripts/ci.py ${{ runner.temp }} ./release-wasm32.sh JavaScript 32 ./tests/ci.json

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,52 @@
+name: Check
+
+on:
+  - push
+  - pull_request
+
+env:
+  CARGO_NET_RETRY: 10
+  CI: 1
+  RUSTUP_MAX_RETRIES: 10
+
+jobs:
+  build:
+    name: CI (macOS)
+    runs-on: macos-14
+    strategy:
+      matrix:
+        target:
+          - aarch64-apple-darwin
+          - wasm32-unknown-unknown
+    env:
+      CARGO_BUILD_TARGET: ${{ matrix.target }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          target: ${{ matrix.target }}
+          profile: default
+          override: true
+          components: clippy
+      - name: Install node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 21
+      - name: Install System packages
+        run: |
+          brew update
+          brew install gcc
+          rustup component add rust-src --toolchain nightly-aarch64-apple-darwin
+      - name: Clippy
+        run: cargo clippy
+        env:
+          RUSTFLAGS: "-D warnings -A clippy::missing_safety_doc"
+      - name: Test
+        if: ${{ matrix.target != 'wasm32-unknown-unknown' }}
+        run: cargo test --lib -- --test-threads 1
+      - name: Check wasm32
+        if: ${{ matrix.target == 'wasm32-unknown-unknown' }}
+        run: |
+          python ./scripts/ci.py ${{ runner.temp }} ./release-wasm32.sh JavaScript 32 ./tests/ci.json

--- a/basm-std/src/platform/codegen.rs
+++ b/basm-std/src/platform/codegen.rs
@@ -1,8 +1,8 @@
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(any(target_arch = "wasm32", target_arch = "aarch64")))]
 use core::arch::asm;
 
 use crate::platform;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(any(target_arch = "wasm32", target_arch = "aarch64")))]
 use crate::platform::loader;
 
 /* We need to support multiple scenarios.

--- a/basm-std/src/platform/codegen.rs
+++ b/basm-std/src/platform/codegen.rs
@@ -41,7 +41,7 @@ use crate::platform::loader;
  *     have done a good job of marking sections needing relocations as writable.
  */
 
-#[cfg(all(not(target_arch = "x86_64"), not(target_arch = "x86"), not(target_arch = "wasm32")))]
+#[cfg(not(any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64", target_arch = "wasm32")))]
 compile_error!("The target architecture is not supported.");
 
 #[cfg(all(target_arch = "x86_64", not(target_os = "windows")))]

--- a/basm-std/src/platform/os/windows.rs
+++ b/basm-std/src/platform/os/windows.rs
@@ -8,7 +8,7 @@ macro_rules! ms_abi {
     (fn $args:tt) => { extern "win64" fn $args };
     (fn $args:tt $arrow: tt $rettype: ty) => { extern "win64" fn $args $arrow $rettype };
 }
-#[cfg(target_arch = "x86")]
+#[cfg(not(target_arch = "x86_64"))]
 macro_rules! ms_abi {
     (fn $args:tt) => { extern "stdcall" fn $args };
     (fn $args:tt $arrow: tt $return_type: ty) => { extern "stdcall" fn $args $arrow $return_type };
@@ -24,7 +24,7 @@ macro_rules! basm_abi {
     ($s1:ident $s2:ident fn $name: ident $args:tt -> $rettype:ty $code: block) =>
         {$s1 $s2 extern "win64" fn $name $args -> $rettype $code };
 }
-#[cfg(target_arch = "x86")]
+#[cfg(not(target_arch = "x86_64"))]
 macro_rules! basm_abi {
     (fn $name:ident $args:tt -> $rettype:ty
          $code: block) =>

--- a/basm/build.rs
+++ b/basm/build.rs
@@ -37,6 +37,18 @@ fn main() {
             }
             link_args_basm_submit.push("-Wl,-z,max-page-size=128");
         },
+        "aarch64-apple-darwin" => {
+            link_args_basm.push("-nostartfiles");
+            link_args_basm.push("-nostdlib");
+            link_args_basm.push("-static-pie");
+            link_args_basm.push("-fno-exceptions");
+            link_args_basm.push("-fno-asynchronous-unwind-tables");
+            link_args_basm.push("-fno-unwind-tables");
+            link_args_basm.push("-fno-stack-protector");
+            link_args_basm.push("-fno-plt");
+            link_args_basm.push("-Wl,--entry=_basm_start,--build-id=none,--gc-sections,--export-dynamic,--no-eh-frame-hdr,-z,norelro");
+            link_args_basm_submit.push("-Wl,-z,max-page-size=128");
+        },
         "wasm32-unknown-unknown" => {
         },
         _ => {

--- a/release-wasm32.sh
+++ b/release-wasm32.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 >&2 echo "Building project for target wasm32-unknown-unknown, language JavaScript, build mode Release"
 cargo +nightly build --target wasm32-unknown-unknown --bin=basm-submit --features=submit --release "$@"
 python3 scripts/wasm-gen.py wasm-template.js JavaScript

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -39,8 +39,8 @@ if __name__ == "__main__":
         sol_path = job["solution"]
         indata_path = job["input"]
         outdata_path = job["output"]
-        completed_process = subprocess.run([
-            "python",
+        completed_process = subprocess.run(" ".join([
+            "python" if os.name == 'nt' else "python3",
             "./scripts/build-and-judge.py",
             tmp_dir,
             build_cmd,
@@ -49,7 +49,7 @@ if __name__ == "__main__":
             sol_path,
             indata_path,
             outdata_path
-        ], shell=True, capture_output=False, text=True)
+        ]), shell=True, capture_output=False, text=True)
         if completed_process.returncode != 0:
             raise Exception("Test script terminated with a non-zero exit code {}.".format(completed_process.returncode))
 


### PR DESCRIPTION
* macOS는 aarch64-apple-darwin과 wasm32-unknown-unknown target을 사용합니다.
* 현재 aarch64는 clippy 및 test만, wasm32는 run만 테스트합니다.
* 추후 aarch64에 대한 codegen 작성 예정입니다.

참고 링크: https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/