### PR TITLE
Fix rust-analyzer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.checkOnSave.allTargets": false
+}


### PR DESCRIPTION
VS Code (특히 GitHub Codespaces에서) rust-analyzer는 기본적으로 Cargo.toml에 설정된 모든 타겟을 빌드하는데, test 타겟을 빌드하면 test가 no-std가 아니기 때문에 충돌이 발생합니다. 따라서 rust-analyzer에서 기본 타겟(bin) 외의 다른 타겟 빌드를 비활성화하여 문제를 해결합니다.