### PR TITLE
Update README.md: use dashu from crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ macOS (AArch64) 환경에서 빌드하는 방법입니다.
 그런 다음, Cargo.toml의 [dependencies] 항목에 다음을 추가합니다.
 
 ```
-dashu = { git = "https://github.com/cmpute/dashu.git", rev = "22f3935", default-features = false, features = [] }
+dashu = { version = "0.4.2", default-features = false }
 ```
 
 basm/src/solution.rs를 다음과 같이 수정합니다.
@@ -286,7 +286,7 @@ chmod +x ./output-32
 
 ```
 nom = { version = "7.1.3", default-features = false, features = ["alloc"] }
-dashu = { git = "https://github.com/cmpute/dashu.git", rev = "22f3935", default-features = false, features = [] }
+dashu = { version = "0.4.2", default-features = false }
 ```
 
 basm/src/solution.rs를 다음과 같이 수정합니다.

--- a/basm-std/src/platform/malloc/dlmalloc_linux.rs
+++ b/basm-std/src/platform/malloc/dlmalloc_linux.rs
@@ -14,6 +14,12 @@ impl System {
     }
 }
 
+impl Default for System {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 unsafe impl DlmallocAllocator for System {
     fn alloc(&self, size: usize) -> (*mut u8, usize, u32) {
         let addr = unsafe {

--- a/basm-std/src/platform/malloc/dlmalloc_macos.rs
+++ b/basm-std/src/platform/malloc/dlmalloc_macos.rs
@@ -14,6 +14,12 @@ impl System {
     }
 }
 
+impl Default for System {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 unsafe impl DlmallocAllocator for System {
     fn alloc(&self, size: usize) -> (*mut u8, usize, u32) {
         let addr = unsafe {

--- a/basm-std/src/platform/malloc/dlmalloc_wasm32.rs
+++ b/basm-std/src/platform/malloc/dlmalloc_wasm32.rs
@@ -15,6 +15,12 @@ impl System {
     }
 }
 
+impl Default for System {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 unsafe impl DlmallocAllocator for System {
     fn alloc(&self, size: usize) -> (*mut u8, usize, u32) {
         let pages = (size + 65535) >> 16;

--- a/basm-std/src/platform/malloc/dlmalloc_windows.rs
+++ b/basm-std/src/platform/malloc/dlmalloc_windows.rs
@@ -14,6 +14,12 @@ impl System {
     }
 }
 
+impl Default for System {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 unsafe impl DlmallocAllocator for System {
     fn alloc(&self, size: usize) -> (*mut u8, usize, u32) {
         let addr = unsafe {


### PR DESCRIPTION
dashu crate (https://crates.io/crates/dashu) 최신 버전(0.4.2)에서 빌드 이슈가 사라진 것을 확인하여 README.md의 dependency 정의를 기존의 git 특정 커밋 지정 방식에서 crates.io 0.4.2 버전 지정으로 교체합니다.