### PR TITLE
Fix compile error on DOMjudge

### DIFF
--- a/basm-std/src/platform/malloc/dlmalloc.rs
+++ b/basm-std/src/platform/malloc/dlmalloc.rs
@@ -1282,7 +1282,7 @@ impl<A: DlmallocAllocator> Dlmalloc<A> {
             released += self.release_unused_segments();
 
             if released == 0 && self.topsize > self.trim_check {
-                self.trim_check = usize::max_value();
+                self.trim_check = usize::MAX;
             }
         }
 

--- a/basm-std/src/platform/os/windows.rs
+++ b/basm-std/src/platform/os/windows.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case)]
+#![allow(clippy::missing_transmute_annotations)]
 
 use super::super::{allocator, services};
 use super::super::malloc::{dlmalloc, dlmalloc_windows};

--- a/scripts/build-and-judge.py
+++ b/scripts/build-and-judge.py
@@ -102,7 +102,7 @@ if __name__ == '__main__':
         if platform.system() == "Windows":
             os.system("cl {0} /F268435456 /Fe{1} /link /SUBSYSTEM:CONSOLE".format(src_path, bin_path))
         else:
-            os.system("gcc -o {1} {2} {0}".format(src_path, bin_path, "-O3 -m32" if bits == 32 else "-O3"))
+            os.system("gcc -DBASM_CI -o {1} {2} {0}".format(src_path, bin_path, "-O3 -m32" if bits == 32 else "-O3"))
     elif language == "Rust":
         if platform.system() == "Windows":
             os.system("rustc -C opt-level=3 -o {1} --crate-type=bin {0}".format(src_path, bin_path))

--- a/scripts/templates/static-pie-template-amd64.c
+++ b/scripts/templates/static-pie-template-amd64.c
@@ -141,7 +141,7 @@ stub_ptr get_stub() {
 #endif
 char payload[][$$$$min_len_4096$$$$] = $$$$binary_base85$$$$;
 
-#if defined(__linux__) && defined(BOJ)
+#if defined(__linux__) && (defined(BOJ) || defined(BASM_CI))
 int main() {}
 #ifdef __cplusplus
 extern "C"

--- a/scripts/templates/static-pie-template-amd64.c
+++ b/scripts/templates/static-pie-template-amd64.c
@@ -141,7 +141,7 @@ stub_ptr get_stub() {
 #endif
 char payload[][$$$$min_len_4096$$$$] = $$$$binary_base85$$$$;
 
-#if defined(__linux__)
+#if defined(__linux__) && defined(BOJ)
 int main() {}
 #ifdef __cplusplus
 extern "C"


### PR DESCRIPTION
static-pie-template-amd64.c의 156/0 관련 코드(__libc_start_main)가 문제를 일으키기 때문에 백준 온라인 저지 매크로(BOJ)가 정의되었거나 CI 테스트 환경 매크로(BASM_CI)가 정의된 경우에만 156/0 관련 코드를 활성화하도록 수정했습니다.

또한, 최신 버전의 rustc nightly에서 발생하는 clippy 이슈를 수정했습니다.

Fixes #85.