### PR TITLE
Add Reeds-Sloane algorithm

### DIFF
--- a/basm-std/src/math.rs
+++ b/basm-std/src/math.rs
@@ -4,6 +4,8 @@ mod sieve;
 pub use sieve::LinearSieve;
 mod pollard_rho;
 pub use pollard_rho::factorize;
+mod reeds_sloane;
+pub use reeds_sloane::linear_fit;
 
 pub mod ntt;
 pub use ntt::*;

--- a/basm-std/src/math.rs
+++ b/basm-std/src/math.rs
@@ -5,7 +5,7 @@ pub use sieve::LinearSieve;
 mod pollard_rho;
 pub use pollard_rho::factorize;
 mod reeds_sloane;
-pub use reeds_sloane::linear_fit;
+pub use reeds_sloane::{linear_fit, reeds_sloane};
 
 pub mod ntt;
 pub use ntt::*;

--- a/basm-std/src/math/reeds_sloane.rs
+++ b/basm-std/src/math/reeds_sloane.rs
@@ -1,0 +1,202 @@
+use alloc::{vec, vec::Vec};
+use core::cmp::max;
+use crate::math::{factorize, modadd, modinv, modmul, modsub};
+
+fn linear_fit_prime_power(first_terms: &[u64], p: u64, e: usize) -> Vec<u64> {
+    let n = first_terms.len();
+    assert!(n >= 2);
+    assert!(p >= 2);
+    assert!(e >= 1);
+
+    let ppow: Vec<u64> = (0..=e).map(|x| p.pow(x as u32)).collect();
+
+    let p_e = ppow[e];
+    let s: Vec<u64> = first_terms.iter().map(|&x| x % p_e).collect();
+
+    // Utility functions
+    fn l(a: &[u64], b: &[u64]) -> usize {
+        max(a.len() - 1, b.len())
+    }
+    fn find_ppow(x: u64, e: usize, ppow: &[u64]) -> (u64, usize) {
+        // Returns (theta, u)
+        let (mut lo, mut hi) = (0, e);
+        while lo < hi {
+            let mid = (lo + hi + 1) / 2;
+            if x % ppow[mid] == 0 {
+                lo = mid;
+            } else {
+                hi = mid - 1;
+            }
+        }
+        (x / ppow[lo], lo)
+    }
+
+    // Step 0
+    let mut a: Vec<Vec<u64>> = vec![];
+    let mut b = vec![];
+    let mut a_new = vec![];
+    let mut b_new = vec![];
+    let mut theta = vec![0; e];
+    let mut u = vec![0; e];
+    for eta in 0..e {
+        let p_eta = ppow[eta];
+        a.push(vec![p_eta]);
+        b.push(vec![]);
+        a_new.push(vec![p_eta]);
+        let p_eta_s0 = modmul(p_eta, s[0], p_e);
+        b_new.push(if p_eta_s0 == 0 { vec![] } else { vec![p_eta_s0] } );
+        let c = modmul(s[0], p_eta, p_e);
+        (theta[eta], u[eta]) = find_ppow(c, e, &ppow);
+    }
+
+    // Step k
+    let mut a_old: Vec<Vec<u64>> = vec![vec![]; e];
+    let mut b_old: Vec<Vec<u64>> = vec![vec![]; e];
+    let mut u_old = vec![0; e];
+    let mut theta_old = vec![0; e];
+    let mut r = vec![0; e];
+    for k in 1..n {
+        // Part 1
+        for g in 0..e {
+            if l(&a_new[g], &b_new[g]) > l(&a[g], &b[g]) {
+                let h = e - 1 - u[g];
+                a_old[g].clone_from(&a[h]);
+                b_old[g].clone_from(&b[h]);
+                u_old[g] = u[h];
+                theta_old[g] = theta[h];
+                r[g] = k - 1;
+            }
+        }
+        // Part 2
+        a.clone_from_slice(&a_new);
+        // Part 3
+        for eta in 0..e {
+            let mut c = modsub(0, if b[eta].len() > k { b[eta][k] } else { 0 }, p_e);
+            for j in 0..=k {
+                if a[eta].len() > j {
+                    c = modadd(c, modmul(s[k - j], a[eta][j], p_e), p_e);
+                }
+            }
+            (theta[eta], u[eta]) = find_ppow(c, e, &ppow);
+            if u[eta] == e {
+                // Case I
+                a_new[eta].clone_from(&a[eta]);
+                b_new[eta].clone_from(&b[eta]);
+            } else {
+                // Case II
+                let g = e - 1 - u[eta];
+                if l(&a[g], &b[g]) == 0 {
+                    // Case IIa
+                    a_new[eta].clone_from(&a[eta]);
+                    let mut tmp = b[eta].clone();
+                    if tmp.len() <= k {
+                        tmp.resize(k + 1, 0);
+                    }
+                    tmp[k] = modadd(tmp[k], modmul(theta[eta], ppow[eta], p_e), p_e);
+                    b_new[eta] = tmp;
+                } else {
+                    // Case IIb
+                    let theta_g_old_inv = modinv(theta_old[g], p_e).unwrap();
+                    let m = modmul(theta[eta], theta_g_old_inv, p_e);
+                    let m = modmul(m, ppow[u[eta] - u_old[g]], p_e);
+                    let d = k - r[g];
+                    let mut tmp = a[eta].clone();
+                    if tmp.len() < a_old[g].len() + d {
+                        tmp.resize(a_old[g].len() + d, 0);
+                    }
+                    for j in 0..a_old[g].len() {
+                        tmp[j + d] = modsub(tmp[j + d], modmul(m, a_old[g][j], p_e), p_e);
+                    }
+                    while tmp.last() == Some(&0) {
+                        tmp.pop();
+                    }
+                    a_new[eta] = tmp;
+                    let mut tmp = b[eta].clone();
+                    if tmp.len() < b_old[g].len() + d {
+                        tmp.resize(b_old[g].len() + d, 0);
+                    }
+                    for j in 0..b_old[g].len() {
+                        tmp[j + d] = modsub(tmp[j + d], modmul(m, b_old[g][j], p_e), p_e);
+                    }
+                    while tmp.last() == Some(&0) {
+                        tmp.pop();
+                    }
+                    b_new[eta] = tmp;
+                }
+            }
+        }
+    }
+
+    // Extract output
+    let mut out = vec![];
+    for i in 1..a_new[0].len() {
+        out.push(modsub(0, a_new[0][i], p_e));
+    }
+    out
+}
+
+/// Finds a minimal length linear recurrence for `first_terms`
+/// under modulo `modulo`, via the Reeds-Sloane algorithm.
+/// 
+/// Note that `modulo` of `0` is interpreted as `2**64`.
+pub fn linear_fit(first_terms: &[u64], modulo: u64) -> Vec<u64> {
+    if first_terms.len() <= 1 {
+        return vec![];
+    }
+    if modulo == 1 {
+        return vec![0];
+    }
+    if modulo == 0 {
+        // We deal with 2**64 first, to ensure modulo > 0 below.
+        return linear_fit_prime_power(first_terms, 2, 64);
+    }
+
+    let factors = {
+        let factors = factorize(modulo);
+        let mut out = vec![];
+        let (mut prev, mut cnt) = (0, 0usize);
+        for f in factors {
+            if f == prev {
+                cnt += 1;
+            } else {
+                if prev != 0 {
+                    out.push((prev, cnt));
+                }
+                (prev, cnt) = (f, 1);
+            }
+        }
+        if prev != 0 {
+            out.push((prev, cnt));
+        }
+        out
+    };
+    let mut out_prime = vec![];
+    let mut max_len = 0;
+    for &(p, e) in factors.iter() {
+        let val = linear_fit_prime_power(first_terms, p, e);
+        max_len = max(val.len(), max_len);
+        out_prime.push((val, p.pow(e as u32)));
+    }
+    for v in out_prime.iter_mut() {
+        v.0.resize(max_len, 0);
+    }
+    let mut out = vec![0; max_len];
+    let mut cumul_mod = 1;
+    for (v, cur_mod) in out_prime {
+        if cumul_mod == 1 {
+            out = v;
+        } else {
+            let (p, q) = (cumul_mod, cur_mod);
+            let (pinv, qinv) = (modinv(p, q).unwrap(), modinv(q, p).unwrap());
+            for i in 0..max_len {
+                // out[i] mod cumul_mod, v[i] mod cur_mod
+                // No overflow since we have ensured p*q < 2**64
+                let mp = modmul(out[i], qinv, p);
+                let mq = modmul(v[i], pinv, q);
+                out[i] = modadd(q * mp, p * mq, p * q);
+            }   
+        }
+        cumul_mod *= cur_mod;
+    }
+    out
+}

--- a/basm-std/src/math/reeds_sloane.rs
+++ b/basm-std/src/math/reeds_sloane.rs
@@ -36,13 +36,22 @@ fn reeds_sloane_prime_power(first_terms: &[u64], p: u64, e: usize) -> Vec<u64> {
         let (mut lo, mut hi) = (0, e);
         while lo < hi {
             let mid = (lo + hi + 1) / 2;
-            if x % ppow[mid] == 0 {
-                lo = mid;
+            #[allow(clippy::collapsible_else_if)]
+            if ppow[mid] == 0 {
+                if x == 0 {
+                    lo = mid;
+                } else {
+                    hi = mid - 1;
+                }
             } else {
-                hi = mid - 1;
+                if x % ppow[mid] == 0 {
+                    lo = mid;
+                } else {
+                    hi = mid - 1;
+                }
             }
         }
-        (x / ppow[lo], lo)
+        (if ppow[lo] == 0 { 0 } else { x / ppow[lo]}, lo)
     };
 
     // Step 0
@@ -239,6 +248,8 @@ mod test {
         let modulo = 1_000_000_007;
         let coeff = linear_fit(&first_terms, modulo);
         assert!(coeff == vec![2, 2, modulo - 1]);
+        let coeff = linear_fit(&first_terms, 0);
+        assert!(coeff == vec![2, 2, u64::MAX]);
     }
 
     #[test]

--- a/basm-std/src/math/reeds_sloane.rs
+++ b/basm-std/src/math/reeds_sloane.rs
@@ -2,7 +2,7 @@ use alloc::{vec, vec::Vec};
 use core::cmp::max;
 use crate::math::{factorize, modadd, modinv, modmul, modsub};
 
-fn linear_fit_prime_power(first_terms: &[u64], p: u64, e: usize) -> Vec<u64> {
+fn reeds_sloane_prime_power(first_terms: &[u64], p: u64, e: usize) -> Vec<u64> {
     let n = first_terms.len();
     assert!(n >= 2);
     assert!(p >= 2);
@@ -153,7 +153,7 @@ fn linear_fit_prime_power(first_terms: &[u64], p: u64, e: usize) -> Vec<u64> {
 /// under modulo `modulo`, via the Reeds-Sloane algorithm.
 /// 
 /// Note that `modulo` of `0` is interpreted as `2**64`.
-pub fn linear_fit(first_terms: &[u64], modulo: u64) -> Vec<u64> {
+pub fn reeds_sloane(first_terms: &[u64], modulo: u64) -> Vec<u64> {
     if first_terms.len() <= 1 {
         return vec![];
     }
@@ -162,7 +162,7 @@ pub fn linear_fit(first_terms: &[u64], modulo: u64) -> Vec<u64> {
     }
     if modulo == 0 {
         // We deal with 2**64 first, to ensure modulo > 0 below.
-        return linear_fit_prime_power(first_terms, 2, 64);
+        return reeds_sloane_prime_power(first_terms, 2, 64);
     }
 
     let factors = {
@@ -187,7 +187,7 @@ pub fn linear_fit(first_terms: &[u64], modulo: u64) -> Vec<u64> {
     let mut out_prime = vec![];
     let mut max_len = 0;
     for &(p, e) in factors.iter() {
-        let val = linear_fit_prime_power(first_terms, p, e);
+        let val = reeds_sloane_prime_power(first_terms, p, e);
         max_len = max(val.len(), max_len);
         out_prime.push((val, p.pow(e as u32)));
     }
@@ -213,4 +213,14 @@ pub fn linear_fit(first_terms: &[u64], modulo: u64) -> Vec<u64> {
         cumul_mod *= cur_mod;
     }
     out
+}
+
+/// This function is an alias for the function `reeds_sloane`.
+///
+/// Finds a minimal length linear recurrence for `first_terms`
+/// under modulo `modulo`, via the Reeds-Sloane algorithm.
+/// 
+/// Note that `modulo` of `0` is interpreted as `2**64`.
+pub fn linear_fit(first_terms: &[u64], modulo: u64) -> Vec<u64> {
+    reeds_sloane(first_terms, modulo)
 }

--- a/basm-std/src/math/reeds_sloane.rs
+++ b/basm-std/src/math/reeds_sloane.rs
@@ -8,7 +8,7 @@ fn reeds_sloane_prime_power(first_terms: &[u64], p: u64, e: usize) -> Vec<u64> {
     assert!(p >= 2);
     assert!(e >= 1);
 
-    let ppow: Vec<u64> = (0..=e).map(|x| p.pow(x as u32)).collect();
+    let ppow: Vec<u64> = (0..=e).map(|x| p.wrapping_pow(x as u32)).collect();
 
     let p_e = ppow[e];
     let s: Vec<u64> = first_terms.iter().map(|&x| if p_e > 0 { x % p_e } else { x }).collect();
@@ -82,7 +82,8 @@ fn reeds_sloane_prime_power(first_terms: &[u64], p: u64, e: usize) -> Vec<u64> {
             }
         }
         // Part 2
-        a.clone_from_slice(&a_new);
+        a.clone_from(&a_new);
+        b.clone_from(&b_new);
         // Part 3
         for eta in 0..e {
             let mut c = modsub_p_e(0, if b[eta].len() > k { b[eta][k] } else { 0 });

--- a/basm-std/src/math/reeds_sloane.rs
+++ b/basm-std/src/math/reeds_sloane.rs
@@ -224,3 +224,27 @@ pub fn reeds_sloane(first_terms: &[u64], modulo: u64) -> Vec<u64> {
 pub fn linear_fit(first_terms: &[u64], modulo: u64) -> Vec<u64> {
     reeds_sloane(first_terms, modulo)
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn check_reeds_sloane_fibosqsum() {
+        let mut first_terms = [0, 1, 1, 2*2, 3*3, 5*5, 8*8, 13*13, 21*21, 34*34, 55*55, 89*89, 144*144, 233*233, 377*377, 610*610, 987*987, 1597*1597];
+        for i in 1..first_terms.len() {
+            first_terms[i] += first_terms[i - 1];
+        }
+        let modulo = 1_000_000_007;
+        let coeff = linear_fit(&first_terms, modulo);
+        assert!(coeff == vec![2, 2, modulo - 1]);
+    }
+
+    #[test]
+    fn check_reeds_sloane_example_in_paper() {
+        let first_terms = [6, 3, 1, 5, 6];
+        let modulo = 9;
+        let coeff = linear_fit(&first_terms, modulo);
+        assert!(coeff == vec![5, 2, 8]);
+    }
+}

--- a/basm-std/src/math/reeds_sloane.rs
+++ b/basm-std/src/math/reeds_sloane.rs
@@ -11,13 +11,27 @@ fn linear_fit_prime_power(first_terms: &[u64], p: u64, e: usize) -> Vec<u64> {
     let ppow: Vec<u64> = (0..=e).map(|x| p.pow(x as u32)).collect();
 
     let p_e = ppow[e];
-    let s: Vec<u64> = first_terms.iter().map(|&x| x % p_e).collect();
+    let s: Vec<u64> = first_terms.iter().map(|&x| if p_e > 0 { x % p_e } else { x }).collect();
 
-    // Utility functions
+    // Utility functions (modulo operations)
+    let modadd_p_e = |x: u64, y: u64| -> u64 {
+        if p_e == 0 { x.wrapping_add(y) } else { modadd(x, y, p_e) }
+    };
+    let modsub_p_e = |x: u64, y: u64| -> u64 {
+        if p_e == 0 { x.wrapping_sub(y) } else { modsub(x, y, p_e) }
+    };
+    let modmul_p_e = |x: u64, y: u64| -> u64 {
+        if p_e == 0 { x.wrapping_mul(y) } else { modmul(x, y, p_e) }
+    };
+    let modinv_p_e = |x: u64| -> u64 {
+        if p_e == 0 { modinv(x as u128, 1u128 << 64).unwrap() as u64 } else { modinv(x, p_e).unwrap() }
+    };
+
+    // Utility functions (core logic)
     fn l(a: &[u64], b: &[u64]) -> usize {
         max(a.len() - 1, b.len())
     }
-    fn find_ppow(x: u64, e: usize, ppow: &[u64]) -> (u64, usize) {
+    let factor_by_p = |x: u64| -> (u64, usize) {
         // Returns (theta, u)
         let (mut lo, mut hi) = (0, e);
         while lo < hi {
@@ -29,7 +43,7 @@ fn linear_fit_prime_power(first_terms: &[u64], p: u64, e: usize) -> Vec<u64> {
             }
         }
         (x / ppow[lo], lo)
-    }
+    };
 
     // Step 0
     let mut a: Vec<Vec<u64>> = vec![];
@@ -43,10 +57,10 @@ fn linear_fit_prime_power(first_terms: &[u64], p: u64, e: usize) -> Vec<u64> {
         a.push(vec![p_eta]);
         b.push(vec![]);
         a_new.push(vec![p_eta]);
-        let p_eta_s0 = modmul(p_eta, s[0], p_e);
+        let p_eta_s0 = modmul_p_e(p_eta, s[0]);
         b_new.push(if p_eta_s0 == 0 { vec![] } else { vec![p_eta_s0] } );
-        let c = modmul(s[0], p_eta, p_e);
-        (theta[eta], u[eta]) = find_ppow(c, e, &ppow);
+        let c = modmul_p_e(s[0], p_eta);
+        (theta[eta], u[eta]) = factor_by_p(c);
     }
 
     // Step k
@@ -71,13 +85,13 @@ fn linear_fit_prime_power(first_terms: &[u64], p: u64, e: usize) -> Vec<u64> {
         a.clone_from_slice(&a_new);
         // Part 3
         for eta in 0..e {
-            let mut c = modsub(0, if b[eta].len() > k { b[eta][k] } else { 0 }, p_e);
+            let mut c = modsub_p_e(0, if b[eta].len() > k { b[eta][k] } else { 0 });
             for j in 0..=k {
                 if a[eta].len() > j {
-                    c = modadd(c, modmul(s[k - j], a[eta][j], p_e), p_e);
+                    c = modadd_p_e(c, modmul_p_e(s[k - j], a[eta][j]));
                 }
             }
-            (theta[eta], u[eta]) = find_ppow(c, e, &ppow);
+            (theta[eta], u[eta]) = factor_by_p(c);
             if u[eta] == e {
                 // Case I
                 a_new[eta].clone_from(&a[eta]);
@@ -92,20 +106,20 @@ fn linear_fit_prime_power(first_terms: &[u64], p: u64, e: usize) -> Vec<u64> {
                     if tmp.len() <= k {
                         tmp.resize(k + 1, 0);
                     }
-                    tmp[k] = modadd(tmp[k], modmul(theta[eta], ppow[eta], p_e), p_e);
+                    tmp[k] = modadd_p_e(tmp[k], modmul_p_e(theta[eta], ppow[eta]));
                     b_new[eta] = tmp;
                 } else {
                     // Case IIb
-                    let theta_g_old_inv = modinv(theta_old[g], p_e).unwrap();
-                    let m = modmul(theta[eta], theta_g_old_inv, p_e);
-                    let m = modmul(m, ppow[u[eta] - u_old[g]], p_e);
+                    let theta_g_old_inv = modinv_p_e(theta_old[g]);
+                    let m = modmul_p_e(theta[eta], theta_g_old_inv);
+                    let m = modmul_p_e(m, ppow[u[eta] - u_old[g]]);
                     let d = k - r[g];
                     let mut tmp = a[eta].clone();
                     if tmp.len() < a_old[g].len() + d {
                         tmp.resize(a_old[g].len() + d, 0);
                     }
                     for j in 0..a_old[g].len() {
-                        tmp[j + d] = modsub(tmp[j + d], modmul(m, a_old[g][j], p_e), p_e);
+                        tmp[j + d] = modsub_p_e(tmp[j + d], modmul_p_e(m, a_old[g][j]));
                     }
                     while tmp.last() == Some(&0) {
                         tmp.pop();
@@ -116,7 +130,7 @@ fn linear_fit_prime_power(first_terms: &[u64], p: u64, e: usize) -> Vec<u64> {
                         tmp.resize(b_old[g].len() + d, 0);
                     }
                     for j in 0..b_old[g].len() {
-                        tmp[j + d] = modsub(tmp[j + d], modmul(m, b_old[g][j], p_e), p_e);
+                        tmp[j + d] = modsub_p_e(tmp[j + d], modmul_p_e(m, b_old[g][j]));
                     }
                     while tmp.last() == Some(&0) {
                         tmp.pop();
@@ -130,7 +144,7 @@ fn linear_fit_prime_power(first_terms: &[u64], p: u64, e: usize) -> Vec<u64> {
     // Extract output
     let mut out = vec![];
     for i in 1..a_new[0].len() {
-        out.push(modsub(0, a_new[0][i], p_e));
+        out.push(modsub_p_e(0, a_new[0][i]));
     }
     out
 }


### PR DESCRIPTION
Reeds-Sloane 알고리즘은 주어진 정수 수열의 최소 길이 선형 점화식을 찾는 알고리즘입니다. Berlekamp-Massey 알고리즘이 소수 모듈로에 대해서만 작동하는 것과 달리, Reeds-Sloane 알고리즘은 임의 모듈로에 대해 작동합니다. 내부적으로는 모듈로를 `basm::math::factorize`로 소인수분해한 뒤, 모듈로의 각 prime power에 대해 핵심 로직을 돌린 다음 중국인의 나머지 정리(CRT)를 이용해 결과를 병합하는 방식으로 작동합니다.

알고리즘 논문 링크(PDF): http://neilsloane.com/doc/Me111.pdf

구현은 완료되었으나 할 일이 두 가지가 남아있습니다.
1) ~~테스트를 추가해야 합니다.~~ 추가 완료되었습니다.
2) ~~현재 구현체 이름을 `basm::math::linear_fit`으로 하였는데, 유지하거나, `basm::math::reeds_sloane`으로 바꾸거나, 아니면 둘 다 제공하거나(이 경우는 하나가 다른 하나의 alias가 됨) 중에서 선택해야 합니다.~~ `basm::math::reeds_sloane`으로 바꾸고, `basm::math::linear_fit`은 alias가 되도록 하였습니다.