### PR TITLE
Add checked modops + Fix linear_nth bug for modulo 2**64 + Refactor

### DIFF
--- a/basm-std/src/math/ntt/linear_recurrence.rs
+++ b/basm-std/src/math/ntt/linear_recurrence.rs
@@ -23,7 +23,7 @@ pub fn linear_nth(first_terms: &[u64], coeff: &[u64], mut n: u128, modulo: u64) 
     } else {
         let mut p_base = vec![]; // The modulo base polynomial of Kitamasa
         for x in coeff.iter().rev() {
-            p_base.push(if modulo == 0 { 0u64.wrapping_sub(modulo) } else { modsub(0, *x, modulo) });
+            p_base.push(if modulo == 0 { 0u64.wrapping_sub(*x) } else { modsub(0, *x, modulo) });
         }
         p_base.push(1);
         let mut p_pow2 = vec![0, 1];
@@ -46,5 +46,18 @@ pub fn linear_nth(first_terms: &[u64], coeff: &[u64], mut n: u128, modulo: u64) 
             ans = if modulo == 0 { ans.wrapping_add(term) } else { modadd(ans, term, modulo) };
         }
         ans
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn check_linear_nth() {
+        let first_terms = [1, 1];
+        let coeff = [1, 1];
+        assert_eq!(34, linear_nth(&first_terms, &coeff, 8, 1_000_000_007));
+        assert_eq!(34, linear_nth(&first_terms, &coeff, 8, 0));
     }
 }

--- a/basm-std/src/math/ntt/linear_recurrence.rs
+++ b/basm-std/src/math/ntt/linear_recurrence.rs
@@ -23,7 +23,7 @@ pub fn linear_nth(first_terms: &[u64], coeff: &[u64], mut n: u128, modulo: u64) 
     } else {
         let mut p_base = vec![]; // The modulo base polynomial of Kitamasa
         for x in coeff.iter().rev() {
-            p_base.push(if modulo == 0 { 0u64.wrapping_sub(*x) } else { modsub(0, *x, modulo) });
+            p_base.push(modsub(0, *x, modulo));
         }
         p_base.push(1);
         let mut p_pow2 = vec![0, 1];
@@ -38,12 +38,8 @@ pub fn linear_nth(first_terms: &[u64], coeff: &[u64], mut n: u128, modulo: u64) 
         let mut ans = 0u64;
         for i in 0..m {
             if i >= p_out.len() { break; }
-            let term = if modulo == 0 {
-                first_terms[i].wrapping_mul(p_out[i])
-            } else {
-                modmul(first_terms[i], p_out[i], modulo)
-            };
-            ans = if modulo == 0 { ans.wrapping_add(term) } else { modadd(ans, term, modulo) };
+            let term = modmul(first_terms[i], p_out[i], modulo);
+            ans = modadd(ans, term, modulo);
         }
         ans
     }


### PR DESCRIPTION
* 그냥 modops 함수들(modadd 등) -> modulo 0인 경우는 modulo가 해당 type의 MAX값 + 1인 2의 거듭제곱인 것으로 처리
* checked_ prefix 붙은 modops 함수들(checked_modadd 등) -> modulo 0이면 panic, otherwise calls non-prefixed routines
* modulo가 음수이면 여전히 오류 처리
* modops의 modulo 0 지원을 이용해 reeds_sloane 및 linear_nth 리팩터링