### PR TITLE
Improve UnionFind & RemUnionFind

### DIFF
--- a/basm-std/src/collections/union_find.rs
+++ b/basm-std/src/collections/union_find.rs
@@ -37,7 +37,7 @@ impl RemUnionFind {
         self.up.push(self.up.len() as u32);
     }
 
-    pub fn try_join(&mut self, u: usize, v: usize) -> bool {
+    pub fn try_union(&mut self, u: usize, v: usize) -> bool {
         let mut u = u;
         let mut v = v;
         while self.up[u] != self.up[v] {
@@ -97,7 +97,7 @@ impl UnionFind {
         self.rank.push(1);
     }
 
-    pub fn root(&mut self, mut u: usize) -> usize {
+    pub fn find(&mut self, mut u: usize) -> usize {
         while u != self.up[u] as usize {
             self.up[u] = self.up[self.up[u] as usize];
             u = self.up[u] as usize;
@@ -105,7 +105,7 @@ impl UnionFind {
         u
     }
 
-    pub fn join(&mut self, mut pu: usize, mut pv: usize) -> usize {
+    pub fn union(&mut self, mut pu: usize, mut pv: usize) -> usize {
         if self.rank[pu] < self.rank[pv] {
             core::mem::swap(&mut pu, &mut pv);
         }

--- a/basm-std/src/collections/union_find.rs
+++ b/basm-std/src/collections/union_find.rs
@@ -6,11 +6,7 @@ pub struct RemUnionFind {
 }
 
 impl RemUnionFind {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn with_len(n: usize) -> Self {
+    pub fn new(n: usize) -> Self {
         Self {
             up: (0..n as u32).collect(),
         }
@@ -63,11 +59,7 @@ pub struct UnionFind {
 }
 
 impl UnionFind {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn with_len(n: usize) -> Self {
+    pub fn new(n: usize) -> Self {
         Self {
             up: (0..n as u32).collect(),
             rank: vec![1; n],

--- a/basm-std/src/collections/union_find.rs
+++ b/basm-std/src/collections/union_find.rs
@@ -6,6 +6,9 @@ pub struct RemUnionFind {
 }
 
 impl RemUnionFind {
+    /// Creates a new instance of `RemUnionFind` with length `n`.
+    /// 
+    /// Pass `n = 0` if an empty instance is desired.
     pub fn new(n: usize) -> Self {
         Self {
             up: (0..n as u32).collect(),
@@ -20,7 +23,11 @@ impl RemUnionFind {
         self.up.is_empty()
     }
 
+    /// Resizes to increase (or keep) the number of elements.
+    /// 
+    /// A runtime error will occur if `n` is smaller than `self.len()`.
     pub fn resize(&mut self, n: usize) {
+        assert!(n >= self.len());
         let mut i = self.up.len();
         self.up.resize_with(n, || {
             let v = i;
@@ -59,10 +66,14 @@ pub struct UnionFind {
 }
 
 impl UnionFind {
+    /// Creates a new instance of `UnionFind` with length `n`.
+    /// 
+    /// Pass `n = 0` if an empty instance is desired.
     pub fn new(n: usize) -> Self {
         Self {
             up: (0..n as u32).collect(),
             rank: vec![1; n],
+            connected_component_count: n
         }
     }
 
@@ -74,7 +85,12 @@ impl UnionFind {
         self.up.is_empty()
     }
 
+    /// Resizes to increase (or keep) the number of elements.
+    /// 
+    /// A runtime error will occur if `n` is smaller than `self.len()`.
     pub fn resize(&mut self, n: usize) {
+        assert!(n >= self.len());
+        self.connected_component_count += n - self.len();
         let mut i = self.up.len();
         self.up.resize_with(n, || {
             let v = i;
@@ -98,6 +114,7 @@ impl UnionFind {
     }
 
     pub fn union(&mut self, mut pu: usize, mut pv: usize) -> usize {
+        assert!(self.up[pu] as usize == pu && self.up[pv] as usize == pv);
         if self.rank[pu] < self.rank[pv] {
             core::mem::swap(&mut pu, &mut pv);
         }

--- a/basm-std/src/collections/union_find.rs
+++ b/basm-std/src/collections/union_find.rs
@@ -17,10 +17,12 @@ impl RemUnionFind {
         }
     }
 
+    /// Returns the number of elements in the current instance.
     pub fn len(&self) -> usize {
         self.up.len()
     }
 
+    /// Returns `true` if the current instance contains no elements.
     pub fn is_empty(&self) -> bool {
         self.up.is_empty()
     }
@@ -99,10 +101,12 @@ impl UnionFind {
         }
     }
 
+    /// Returns the number of elements in the current instance.
     pub fn len(&self) -> usize {
         self.up.len()
     }
 
+    /// Returns `true` if the current instance contains no elements.
     pub fn is_empty(&self) -> bool {
         self.up.is_empty()
     }
@@ -139,6 +143,7 @@ impl UnionFind {
         self.connected_component_count += 1;
     }
 
+    /// Finds the representative of `u`.
     pub fn find(&mut self, mut u: usize) -> usize {
         while u != self.up[u] as usize {
             self.up[u] = self.up[self.up[u] as usize];

--- a/basm-std/src/collections/union_find.rs
+++ b/basm-std/src/collections/union_find.rs
@@ -168,4 +168,16 @@ impl UnionFind {
         }
         pu
     }
+
+    /// Tries to unite `u` and `v`.
+    /// 
+    /// Returns `true` if a new union is created, `false` otherwise.
+    /// 
+    /// Both `u` and `v` should be strictly less than `self.len()`.
+    /// A runtime error will occur otherwise.
+    pub fn try_union(&mut self, u: usize, v: usize) -> bool {
+        let (pu, pv) = (self.find(u), self.find(v));
+        self.union(pu, pv);
+        pu != pv
+    }
 }


### PR DESCRIPTION
변경 사항 요약:
* `connected_component_count()` 메서드를 추가했습니다. 짧은 alias로 `cc_count()`도 함께 추가했습니다.
* 크기가 단조증가하도록 `assert!`를 추가했습니다.
* 주석을 추가했습니다.

제가 구현한 클래스들이 아니라서 kiwiyou님께서 기능상 문제나 설명 오류 등이 없는지 확인해주시면 좋을 것 같습니다.
Baekjoon Online Judge 7439번에서 정상 작동은 확인했습니다.

UnionFind <http://boj.kr/51ebce58157a4e61ac20f795b0653cc6>
RemUnionFind <http://boj.kr/3475d43b277043df8e4ceba8557d5eff>