### PR TITLE
Fix CI by upgrading compiler-builtins (0.1.111 -> 0.1.113)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,7 +5,7 @@ rustflags = ["-Z", "share-generics=no", "-Z", "export-executable-symbols", "-C",
 rustflags = ["-Z", "share-generics=no", "-C", "relocation-model=pie"]
 
 [target.x86_64-pc-windows-gnu]
-rustflags = ["-Z", "share-generics=no", "-Z", "export-executable-symbols", "-C", "lto=thin", "-C", "target-feature=+avx,+avx2,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+fma,+f16c,+aes", "-C", "relocation-model=pie", "-C", "target-cpu=haswell"]
+rustflags = ["-Z", "share-generics=no", "-Z", "export-executable-symbols", "-C", "embed-bitcode=yes", "-C", "lto=thin", "-C", "target-feature=+avx,+avx2,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+fma,+f16c,+aes", "-C", "relocation-model=pie", "-C", "target-cpu=haswell"]
 linker = "x86_64-w64-mingw32-gcc"
 
 [target.wasm32-unknown-unknown]

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -38,9 +38,7 @@ jobs:
           rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
           python -m pip install pefile
       - name: Clippy
-        run: cargo clippy --all-targets
-        env:
-          RUSTFLAGS: "-D warnings -A clippy::missing_safety_doc"
+        run: cargo clippy --all-targets -- -D warnings -A clippy::missing_safety_doc
       - name: Rustfmt
         run: cargo fmt --check --all
       - name: Test

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -39,9 +39,7 @@ jobs:
           brew install gcc
           rustup component add rust-src --toolchain nightly-aarch64-apple-darwin
       - name: Clippy
-        run: cargo clippy --all-targets
-        env:
-          RUSTFLAGS: "-D warnings -A clippy::missing_safety_doc"
+        run: cargo clippy --all-targets -- -D warnings -A clippy::missing_safety_doc
       - name: Rustfmt
         run: cargo fmt --check --all
       - name: Test

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -37,9 +37,7 @@ jobs:
         run: |
           python -m pip install pefile
       - name: Clippy
-        run: cargo clippy --all-targets
-        env:
-          RUSTFLAGS: "-D warnings -A clippy::missing_safety_doc"
+        run: cargo clippy --all-targets -- -D warnings -A clippy::missing_safety_doc
       - name: Rustfmt
         run: cargo fmt --check --all
       - name: Test

--- a/basm-std/Cargo.toml
+++ b/basm-std/Cargo.toml
@@ -15,17 +15,17 @@ libm = "0.2.7"
 ryu = "1.0"
 
 [target.x86_64-pc-windows-msvc.dependencies]
-compiler_builtins = { version = "0.1.111", features = ["mem"] }
+compiler_builtins = { version = "0.1.113", features = ["mem"] }
 [target.x86_64-pc-windows-gnu.dependencies]
-compiler_builtins = { version = "0.1.111", features = ["mem"] }
+compiler_builtins = { version = "0.1.113", features = ["mem"] }
 [target.x86_64-unknown-linux-gnu.dependencies]
-compiler_builtins = { version = "0.1.111", features = ["mem"] }
+compiler_builtins = { version = "0.1.113", features = ["mem"] }
 [target.i686-unknown-linux-gnu.dependencies]
-compiler_builtins = { version = "0.1.111", features = ["mem"] }
+compiler_builtins = { version = "0.1.113", features = ["mem"] }
 [target.aarch64-apple-darwin.dependencies]
-compiler_builtins = { version = "0.1.111", features = ["mem"] }
+compiler_builtins = { version = "0.1.113", features = ["mem"] }
 [target.wasm32-unknown-unknown.dependencies]
-compiler_builtins = { version = "0.1.111", features = ["mem"] }
+compiler_builtins = { version = "0.1.113", features = ["mem"] }
 
 [features]
 # Enables codegen routines.

--- a/basm/Cargo.toml
+++ b/basm/Cargo.toml
@@ -30,15 +30,15 @@ basm-macro = { path = "../basm-macro" }
 basm-std = { path = "../basm-std", features = ["codegen"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-compiler_builtins = { version = "0.1.111", features = ["mem"] }
+compiler_builtins = { version = "0.1.113", features = ["mem"] }
 [target.x86_64-pc-windows-gnu.dependencies]
-compiler_builtins = { version = "0.1.111", features = ["mem"] }
+compiler_builtins = { version = "0.1.113", features = ["mem"] }
 [target.x86_64-unknown-linux-gnu.dependencies]
-compiler_builtins = { version = "0.1.111", features = ["mem"] }
+compiler_builtins = { version = "0.1.113", features = ["mem"] }
 [target.i686-unknown-linux-gnu.dependencies]
-compiler_builtins = { version = "0.1.111", features = ["mem"] }
+compiler_builtins = { version = "0.1.113", features = ["mem"] }
 [target.wasm32-unknown-unknown.dependencies]
-compiler_builtins = { version = "0.1.111", features = ["mem"] }
+compiler_builtins = { version = "0.1.113", features = ["mem"] }
 
 [features]
 short = ["basm-std/short"]

--- a/basm/src/bin/lang_items.rs
+++ b/basm/src/bin/lang_items.rs
@@ -18,12 +18,6 @@ mod runtime {
         unsafe { core::hint::unreachable_unchecked() }
     }
 
-    // Temporary fix for Windows build failure.
-    // This should be removed later.
-    #[no_mangle]
-    #[cfg(target_os = "windows")]
-    extern "win64" fn __unordtf2() {}
-
     #[no_mangle]
     #[allow(non_snake_case)]
     fn _Unwind_Resume() {


### PR DESCRIPTION
* Previously, the `basm` crate defined a dummy symbol called `__unordtf2` on Windows targets to temporarily mitigate the linking error (undefined external symbol(s)).
* It now seems like the issue has been fixed in `compiler-builtins` upstream; so the temporary mitigation now leads to duplicate symbol names error in linking time.
* Hence, this commit resolves the linking error by removing the temporary mitigation.